### PR TITLE
Let's commit gradlew files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,4 @@ build/
 .jekyll-metadata
 node_modules/
 out/
-gradle/
-gradlew
-gradlew.bat
 code.iml


### PR DESCRIPTION
The project root `.gitignore` had listed `gradlew`, `gradlew.bat`, and `gradle/` as excludes. By convention, these should be committed to repos to enable the Gradle Wrapper, which is itself a very good idea in the context of Developer recipes. Merge this PR to make it happen.