### PR TITLE
Adding Gradle project name metadata

### DIFF
--- a/_includes/recipes/filtering/kafka/code/settings.gradle
+++ b/_includes/recipes/filtering/kafka/code/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'filtering-kafka'

--- a/_includes/recipes/filtering/kstreams/code/settings.gradle
+++ b/_includes/recipes/filtering/kstreams/code/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'filtering-kstreams'

--- a/_includes/recipes/joining/kstreams/code/settings.gradle
+++ b/_includes/recipes/joining/kstreams/code/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'joining'

--- a/_includes/recipes/merging/kstreams/code/settings.gradle
+++ b/_includes/recipes/merging/kstreams/code/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'merging'

--- a/_includes/recipes/splitting/kstreams/code/settings.gradle
+++ b/_includes/recipes/splitting/kstreams/code/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'splitting'

--- a/_includes/recipes/transforming/kstreams/code/settings.gradle
+++ b/_includes/recipes/transforming/kstreams/code/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'transforming'


### PR DESCRIPTION
Team,

Here's a very small PR that improves gradle project representation IDE's like intelij (screenshot).
Also, all new recipes should include this `settings.gradle` (in fact it generates is `gradle init` task used to start new gradle project).

_before PR it's very difficult to navigate in IDE between multiple recipes_

<img width="364" alt="confluent-developer  ~:projects:confluent:confluent-developer  -  :README md  confluent-developer  2019-07-02 10-27-46" src="https://user-images.githubusercontent.com/433085/60522829-b3bd8100-9cb7-11e9-97f9-90ee71e9ed92.png">

_with this PR_
<img width="431" alt="confluent-developer  ~:projects:confluent:confluent-developer  -  :harness_runner:ksql py  confluent-developer  2019-07-02 10-47-35" src="https://user-images.githubusercontent.com/433085/60522911-d6e83080-9cb7-11e9-8e62-697c9b231b07.png">

Thank you