### PR TITLE
Automate S3 deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ code.iml
 .settings/
 .project
 bin/
+s3_website.yml
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source "https://rubygems.org"
 
 gem "jekyll", "3.8.5"
+gem "s3_website", "3.4.0"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,24 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    aws-eventstream (1.0.3)
+    aws-sdk (2.11.315)
+      aws-sdk-resources (= 2.11.315)
+    aws-sdk-core (2.11.315)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.11.315)
+      aws-sdk-core (= 2.11.315)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     colorator (1.1.0)
+    colored (1.2)
     concurrent-ruby (1.1.5)
+    configure-s3-website (2.3.0)
+      aws-sdk (~> 2)
+      deep_merge (~> 1.0.0)
+    deep_merge (1.0.1)
+    dotenv (1.0.2)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -31,6 +47,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    jmespath (1.4.0)
     kramdown (1.17.0)
     liquid (4.0.3)
     listen (3.1.5)
@@ -46,18 +63,25 @@ GEM
       ffi (~> 1.0)
     rouge (3.3.0)
     ruby_dep (1.5.0)
+    s3_website (3.4.0)
+      colored (= 1.2)
+      configure-s3-website (= 2.3.0)
+      dotenv (~> 1.0)
+      thor (~> 0.18)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    thor (0.20.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   jekyll (= 3.8.5)
+  s3_website (= 3.4.0)
 
 BUNDLED WITH
    2.0.1


### PR DESCRIPTION
This is really just a matter of some changes to the `Gemfile` and the `.gitignore` file. A quick `bundle install` will give you access to the `s3_website` gem. With its `s3_website.yml` file in place in the root directory, providing the S3 bucket and region and the AWS key and secret, this gives us the ability to publish the site using `s3_website push` (after a swift `jekyll build`, of course). I plan on storing the yaml file in LastPass, such that only people with access to that file in LastPass will actually be able to do the automated deploy. 