### PR TITLE
Add missing step

### DIFF
--- a/_includes/recipes/tumbling-windows/ksql/markup/try_it.html
+++ b/_includes/recipes/tumbling-windows/ksql/markup/try_it.html
@@ -66,3 +66,10 @@
   <p> Notice that the key for each message contains some strange characters that aren't quite printable. KSQL has combined the grouping key (movie title) with its window boundaries using a format that's not quite printable in this format. It should look something like this:</p>
   <pre class="snippet"><code class="shell">{% include_raw recipes/tumbling-windows/ksql/code/recipe-steps/dev/outputs/print-topic/output-0.log %}</code></pre>
 </div>
+
+<div class="recipe-try-it-step">
+  <h4 class="subtitle"><div>5. Write your statements to a file</div></h4>
+
+  <p>Now that you have a series of statements that's doing the right thing, the last step is to put them into a file so that they can be used outside the CLI session. Create a file at <code>src/statements.sql</code> with the following content:</p>
+  <pre class="snippet"><code class="sql">{% include_raw recipes/tumbling-windows/ksql/code/src/statements.sql %}</code></pre>
+</div>


### PR DESCRIPTION
Without this step the `src/statements.sql` file isn't created by the user, and the test fails to run. 