### PR TITLE
Updated the Confluent Platform version to 5.3.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ exclude:
   - CONTRIBUTING.md
 
 ak_javadoc_version: 23
-cp_version: v5.2.1
+cp_version: v5.3.0
 google_tag_manager_id: GTM-NBVX4Z
 
 plugins:

--- a/_includes/tutorials/transforming/kafka/code/configuration/test.properties
+++ b/_includes/tutorials/transforming/kafka/code/configuration/test.properties
@@ -1,4 +1,4 @@
-confluent.version=5.2.1
+confluent.version=5.3.0
 bootstrap.servers=localhost:29092
 schema.registry.url=http://localhost:8081
 


### PR DESCRIPTION
Virtually all tutorials have this link to `_includes/shared-content/docker-install.txt` that specifies how the user will get Confluent Platform. Currently. the version used is **v5.2.1** which is outdated.

![image](https://user-images.githubusercontent.com/35476/62987427-c4f8c200-be0d-11e9-82ac-0a5a7776ad0e.png)

This PR changes it to **v5.3.0** which is in line to what we're currently using in our docker-compose.yml file.