### PR TITLE
Deploy preview site automatically

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -120,9 +120,9 @@ blocks:
             - make -C _includes/tutorials/rekeying-function/ksql/code tutorial
 
   - name: Deploy the site to staging
+    skip:
+      when: branch != 'master' AND branch !~ '.*staging.*'
     task:
-      skip:
-        when: "branch != 'master' AND branch !~ '.*staging.*'"
       secrets:
         - name: aws_credentials
       prologue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,9 +31,9 @@ blocks:
             - make -C _includes/tutorials/transforming/ksql/code tutorial
 
         - name: KStreams transforming tests
-          commands:                      
+          commands:
             - make -C _includes/tutorials/transforming/kstreams/code tutorial
-            
+
         - name: Kafka transforming tests
           commands:
             - make -C _includes/tutorials/transforming/kafka/code tutorial
@@ -117,3 +117,16 @@ blocks:
         - name: KSQL rekey stream with function
           commands:
             - make -C _includes/tutorials/rekeying-function/ksql/code tutorial
+
+  - name: Deploy the site to staging
+    task:
+      secrets:
+        - name: aws_credentials
+      prologue:
+        commands:
+          - checkout
+      jobs:
+        - name: Copy to S3
+          commands:
+            - aws s3 cp --recursive ./_site "s3://kafka-tutorials-staging/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA/"
+            - echo "Deployed to http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA/"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -121,6 +121,8 @@ blocks:
 
   - name: Deploy the site to staging
     task:
+      skip:
+        when: branch != 'master' AND branch !~ '.*staging.*'
       secrets:
         - name: aws_credentials
       prologue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -122,7 +122,7 @@ blocks:
   - name: Deploy the site to staging
     task:
       skip:
-        when: branch != 'master' AND branch !~ '.*staging.*'
+        when: "branch != 'master' AND branch !~ '.*staging.*'"
       secrets:
         - name: aws_credentials
       prologue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ blocks:
       jobs:
         - name: Compile with Jekyll
           commands:
-            - bundle exec jekyll build
+            - bundle exec jekyll build --baseurl "/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA"
             - cache store site-$SEMAPHORE_GIT_SHA _site
 
   - name: Run the tests

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,6 +18,7 @@ blocks:
         - name: Compile with Jekyll
           commands:
             - bundle exec jekyll build
+            - cache store site-$SEMAPHORE_GIT_SHA _site
 
   - name: Run the tests
     task:
@@ -128,5 +129,7 @@ blocks:
       jobs:
         - name: Copy to S3
           commands:
+            - cache restore site-$SEMAPHORE_GIT_SHA
             - aws s3 cp --recursive ./_site "s3://kafka-tutorials-staging/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA/"
             - echo "Deployed to http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA/"
+            - cache delete site-$SEMAPHORE_GIT_SHA

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: "Kafka Tutorials: Learn Kafka with End-to-End Code Examples"
 description: "Find, learn, and contribute Apache Kafka tutorials with full code examples for real use cases. Learn Kafka from Confluent, the real-time event streaming experts."
-baseurl: ""
+
 url: "http://kafka-tutorials.confluent.io"
 
 github_url: https://github.com/confluentinc/kafka-tutorials

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -6,7 +6,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="container">
     <div>
       <a href="/">
-        <img class="logo" src="/assets/img/logo.svg" alt="Confluent" />
+        <img class="logo" src="{{ "/assets/img/logo.svg" | relative_url }}" alt="Confluent" />
       </a>
     </div>
     <div class="join">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,7 +5,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <nav>
   <div class="container">
     <div>
-      <a href="/">
+      <a href="{{ "/" | relative_url }}">
         <img class="logo" src="{{ "/assets/img/logo.svg" | relative_url }}" alt="Confluent" />
       </a>
     </div>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -14,7 +14,7 @@
 
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/styles/github.min.css" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/assets/sass/main.css" />
+  <link rel="stylesheet" href="{{ "/assets/sass/main.css" | relative_url }}" />
 </head>
 <body class="pg-tutorial">
   {% include nav.html %}
@@ -35,7 +35,7 @@
 
   <section class="section">
     <div class="container">
-      <a href="{{ site.github_url }}" class="btn-edit"><img src="/assets/img/icon-edit.svg" alt="Edit this page" /></a>
+      <a href="{{ site.github_url }}" class="btn-edit"><img src="{{ "/assets/img/icon-edit.svg" | relative_url }}" alt="Edit this page" /></a>
       {% unless page.help_wanted %}
         <div class="example">
           <h3 class="title">Example use case:</h3>
@@ -46,17 +46,17 @@
       <div class="cflt-options">
         <select>
           {% if site.data.tutorials[page.static_data].status.ksql == 'enabled' %}
-          <option value="{{ site.data.tutorials[page.static_data].slug }}/ksql.html" {% if page.stack == 'ksql' %} selected {% endif %}>
+          <option value="{{ site.data.tutorials[page.static_data].slug | relative_url }}/ksql.html" {% if page.stack == 'ksql' %} selected {% endif %}>
             KSQL
           </option>
           {% endif %}
           {% if site.data.tutorials[page.static_data].status.kstreams == 'enabled' %}
-          <option value="{{ site.data.tutorials[page.static_data].slug }}/kstreams.html" {% if page.stack == 'kstreams' %} selected {% endif %}>
+          <option value="{{ site.data.tutorials[page.static_data].slug | relative_url }}/kstreams.html" {% if page.stack == 'kstreams' %} selected {% endif %}>
             Kafka Streams
           </option>
-          {% endif %}
+          {% endif %}.0
           {% if site.data.tutorials[page.static_data].status.kafka == 'enabled' %}
-          <option value="{{ site.data.tutorials[page.static_data].slug }}/kafka.html" {% if page.stack == 'kafka' %} selected {% endif %}>
+          <option value="{{ site.data.tutorials[page.static_data].slug | relative_url }}/kafka.html" {% if page.stack == 'kafka' %} selected {% endif %}>
             Vanilla Kafka
           </option>
           {% endif %}
@@ -65,17 +65,17 @@
       <div class="cflt-tabs">
         <div class="buttons">
           {% if site.data.tutorials[page.static_data].status.ksql == 'enabled' %}
-          <a class="button {% if page.stack == 'ksql' %} is-selected {% endif %}" href="{{ site.data.tutorials[page.static_data].slug }}/ksql.html">
+          <a class="button {% if page.stack == 'ksql' %} is-selected {% endif %}" href="{{ site.data.tutorials[page.static_data].slug | relative_url }}/ksql.html">
             KSQL
           </a>
           {% endif %}
           {% if site.data.tutorials[page.static_data].status.kstreams == 'enabled' %}
-          <a class="button {% if page.stack == 'kstreams' %} is-selected {% endif %}" href="{{ site.data.tutorials[page.static_data].slug }}/kstreams.html">
+          <a class="button {% if page.stack == 'kstreams' %} is-selected {% endif %}" href="{{ site.data.tutorials[page.static_data].slug | relative_url }}/kstreams.html">
             Kafka Streams
           </a>
           {% endif %}
           {% if site.data.tutorials[page.static_data].status.kafka == 'enabled' %}
-          <a class="button {% if page.stack == 'kafka' %} is-selected {% endif %}" href="{{ site.data.tutorials[page.static_data].slug }}/kafka.html">
+          <a class="button {% if page.stack == 'kafka' %} is-selected {% endif %}" href="{{ site.data.tutorials[page.static_data].slug | relative_url }}/kafka.html">
             Vanilla Kafka
           </a>
           {% endif %}
@@ -121,10 +121,10 @@
 
   {% include footer.html %}
 
-  <script src="/assets/js/jquery.min.js"></script>
+  <script src="{{ "/assets/js/jquery.min.js" | relative_url }}"></script>
   <script src="https://use.fontawesome.com/releases/v5.9.0/js/all.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
-  <script src="/assets/js/tutorial.js"></script>
+  <script src="{{ "/assets/js/tutorial.js" | relative_url }}"></script>
 </body>
 </html>

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -171,7 +171,7 @@ body {
 
 .hero {
   background-color: #f9f9fa;
-  background-image: url("/assets/img/hero.png");
+  background-image: url("../img/hero.png");
   background-position: 0 0;
   background-repeat: no-repeat;
   background-size: cover;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="/assets/sass/main.css" />
+    <link rel="stylesheet" href="{{ "/assets/sass/main.css" | relative_url }}" />
   </head>
   <body class="pg-main">
     {% include nav.html %}
@@ -35,39 +35,39 @@
       <div class="cards">
         <div class="card">
           <div class="title">
-            <img src="/assets/img/icon-function.svg" />
+            <img src="{{ "/assets/img/icon-function.svg"  | relative_url }}" />
             <div>Apply a function to data.</div>
           </div>
           <ul>
-            <li><a href="/transform-a-stream-of-events/ksql.html">Transform a stream of events</a></li>
-            <li><a href="/filter-a-stream-of-events/ksql.html">Filter a stream of events</a></li>
-            <li><a href="/rekey-a-stream/ksql.html">Rekey a stream with a value</a></li>
-            <li><a href="/rekey-with-function/ksql.html">Rekey a stream with a function</a></li>
-            <li><a href="/changing-serialization-format/ksql.html">Convert a stream's serialization format</a></li>
-            <li><a href="/split-a-stream-of-events-into-substreams/ksql.html">Split a stream of events into substreams</a></li>
-            <li><a href="/merge-many-streams-into-one-stream/ksql.html">Merge many streams into one stream</a></li>
+            <li><a href="transform-a-stream-of-events/ksql.html">Transform a stream of events</a></li>
+            <li><a href="filter-a-stream-of-events/ksql.html">Filter a stream of events</a></li>
+            <li><a href="rekey-a-stream/ksql.html">Rekey a stream with a value</a></li>
+            <li><a href="rekey-with-function/ksql.html">Rekey a stream with a function</a></li>
+            <li><a href="changing-serialization-format/ksql.html">Convert a stream's serialization format</a></li>
+            <li><a href="split-a-stream-of-events-into-substreams/ksql.html">Split a stream of events into substreams</a></li>
+            <li><a href="merge-many-streams-into-one-stream/ksql.html">Merge many streams into one stream</a></li>
           </ul>
         </div>
         <div class="card">
           <div class="title">
-            <img class="icon-aggregate" src="/assets/img/icon-aggregate.svg" />
+            <img class="icon-aggregate" src="{{ "/assets/img/icon-aggregate.svg" | relative_url }}" />
             <div>Aggregate data.</div>
           </div>
           <ul>
-            <li><a href="/create-stateful-aggregation-count/ksql.html">Count a stream of events</a></li>
-            <li><a href="/create-stateful-aggregation-sum/ksql.html">Sum a stream of events</a></li>
-            <li><a href="/create-stateful-aggregation-minmax/ksql.html">Find the min/max in a stream of events</a></li>
+            <li><a href="create-stateful-aggregation-count/ksql.html">Count a stream of events</a></li>
+            <li><a href="create-stateful-aggregation-sum/ksql.html">Sum a stream of events</a></li>
+            <li><a href="create-stateful-aggregation-minmax/ksql.html">Find the min/max in a stream of events</a></li>
           </ul>
         </div>
         <div class="card">
           <div class="title">
-            <img src="/assets/img/icon-join.svg" />
+            <img src="{{ "/assets/img/icon-join.svg" | relative_url }}" />
             <div>Join data.</div>
           </div>
           <ul>
-            <li><a href="/join-a-stream-to-a-table/ksql.html">Join a stream and a table together</a></li>
-            <li><a href="/join-a-stream-to-a-stream/ksql.html">Join a stream and a stream together</a></li>
-            <li><a href="/join-a-table-to-a-table/ksql.html">Join a table and a table together</a></li>
+            <li><a href="join-a-stream-to-a-table/ksql.html">Join a stream and a table together</a></li>
+            <li><a href="join-a-stream-to-a-stream/ksql.html">Join a stream and a stream together</a></li>
+            <li><a href="join-a-table-to-a-table/ksql.html">Join a table and a table together</a></li>
           </ul>
         </div>
       </div>
@@ -75,11 +75,11 @@
       <div class="cards secondary-card-row">
         <div class="card">
           <div class="title">
-            <img src="/assets/img/icon-time.svg" />
+            <img src="{{ "/assets/img/icon-time.svg" | relative_url }}" />
             <div>Collect data over time.</div>
           </div>
           <ul>
-            <li><a href="/create-tumbling-windows/ksql.html">Create tumbling windows</a></li>
+            <li><a href="create-tumbling-windows/ksql.html">Create tumbling windows</a></li>
           </ul>
         </div>
         <div class="card card-cta">
@@ -100,8 +100,8 @@
     </div>
 
     {% include footer.html %}
-    <script src="/assets/js/jquery.min.js"></script>
-    <script src="/assets/js/main.js"></script>
+    <script src="{{ "/assets/js/jquery.min.js" | relative_url }}"></script>
+    <script src="{{ "/assets/js/main.js" | relative_url }}"></script>
     <script src="//go.confluent.io/js/forms2/js/forms2.min.js"></script>
     <script src="https://use.fontawesome.com/releases/v5.9.0/js/all.js"></script>
   </body>


### PR DESCRIPTION
Deploy selected branches automatically to the new staging site from CI. With this PR, auto-deployment is enabled for branches with names that include `staging` (e.g. `foo-staging`) and the `master` branch itself.

- Each set of staging site artifacts is deleted after seven days.
- Pathnames are based on the branch name and commit SHA. The hostname is `kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com`. Successful builds include the artifact url in the build output, e.g:
> Deployed to http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/ci-staging/e76625413afef67457c48ef3c66059a6f5813c4a/

Note: These changes do not include any promotion to `kafka-tutorials.confluent.io`.

 

