### PR TITLE
Release live site from Semaphore

### DIFF
--- a/.semaphore/live-site-deploy.yml
+++ b/.semaphore/live-site-deploy.yml
@@ -1,0 +1,18 @@
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - task:
+      jobs:
+        - name: Compile and deploy site
+          commands:
+            - checkout
+            - cache restore
+            - npm install
+            - gem install bundler --no-ri --no-rdoc
+            - bundle install            
+            - JEKYLL_ENV=production bundle exec jekyll build
+#            - aws s3 cp --recursive ./_site s3://kafka-tutorials.confluent.io/
+            - cat _site/index.html

--- a/.semaphore/live-site-deploy.yml
+++ b/.semaphore/live-site-deploy.yml
@@ -1,3 +1,5 @@
+version: v1.0
+name: Kafka Tutorials live site deployment
 agent:
   machine:
     type: e1-standard-2

--- a/.semaphore/live-site-deploy.yml
+++ b/.semaphore/live-site-deploy.yml
@@ -7,6 +7,8 @@ agent:
 
 blocks:
   - task:
+      secrets:
+        - name: aws_credentials
       jobs:
         - name: Compile and deploy site
           commands:
@@ -16,4 +18,4 @@ blocks:
             - gem install bundler --no-ri --no-rdoc
             - bundle install            
             - JEKYLL_ENV=production bundle exec jekyll build
-            - aws s3 cp --recursive ./_site s3://kafka-tutorials.confluent.io/            
+            - aws s3 cp --dryrun --recursive ./_site s3://kafka-tutorials.confluent.io/

--- a/.semaphore/live-site-deploy.yml
+++ b/.semaphore/live-site-deploy.yml
@@ -16,5 +16,4 @@ blocks:
             - gem install bundler --no-ri --no-rdoc
             - bundle install            
             - JEKYLL_ENV=production bundle exec jekyll build
-#            - aws s3 cp --recursive ./_site s3://kafka-tutorials.confluent.io/
-            - cat _site/index.html
+            - aws s3 cp --recursive ./_site s3://kafka-tutorials.confluent.io/            

--- a/.semaphore/live-site-deploy.yml
+++ b/.semaphore/live-site-deploy.yml
@@ -18,4 +18,4 @@ blocks:
             - gem install bundler --no-ri --no-rdoc
             - bundle install            
             - JEKYLL_ENV=production bundle exec jekyll build
-            - aws s3 cp --dryrun --recursive ./_site s3://kafka-tutorials.confluent.io/
+            - aws s3 cp --recursive ./_site s3://kafka-tutorials.confluent.io/

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ promotions:
     auto_promote_on:
       - result: passed
         branch:
-          - release
+          - ^release$
 
 blocks:
   - name: Build the website

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,15 +5,25 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 
+promotions:
+  - name: Deploy to live site
+    pipeline_file: live-site-deploy.yml
+    auto_promote_on:
+      - result: passed
+        branch:
+          - release
+
 blocks:
   - name: Build the website
     task:
       prologue:
         commands:
           - checkout
+          - cache restore
           - npm install
           - gem install bundler --no-ri --no-rdoc
           - bundle install
+          - cache store
       jobs:
         - name: Compile with Jekyll
           commands:

--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ You can do the same for Kafka Streams and Kafka, by using the `kstreams` and `ka
 
 Lastly, create a Makefile in the `code` directory to invoke the harness runner and check any outputs that it produces. Then modify the `.semaphore/semaphore.yml` file to invoke that Makefile. This will make sure your tutorial gets checked by the CI system.
 
-## Misc
+## Updating kafka-tutorials.confluent.io
 
-### Running the tests locally
+The `release` branch tracks the content and code comprising the live site. Confluent manages the release process.
 
-Some of the tests require Docker containers to be up. In the root directory, `cd` to the `docker` directory and run `docker-compose up -d` where needed.
+#### Prepare a release PR
+
+A pull request into the `release` branch denotes a request to update the live site. The PR description should summarize the content changes and link to the staging site with the updates. In general, releases are timed, so target dates should also be noted.
+
+Release artifacts are automatically promoted to the live site by CI, as part of successful `release` branch builds.


### PR DESCRIPTION
As described in the readme update:
```
## Updating kafka-tutorials.confluent.io

The `release` branch tracks the content and code comprising the live site. Confluent manages the release process.

#### Prepare a release PR

A pull request into the `release` branch denotes a request to update the live site. The PR description should summarize the content changes and link to the staging site with the updates. In general, releases are timed, so target dates should also be noted.

Release artifacts are automatically promoted to the live site by CI, as part of successful `release` branch builds.
```