### PR TITLE
Make preview site deployment pattern consistent with prod

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,6 +13,13 @@ promotions:
         branch:
           - ^release$
 
+  - name: Deploy to staging site
+    pipeline_file: staging-site-deploy.yml
+    auto_promote_on:
+      - result: passed
+        branch:
+          - ^master$
+
 blocks:
   - name: Build the website
     task:
@@ -128,20 +135,3 @@ blocks:
         - name: KSQL rekey stream with function
           commands:
             - make -C _includes/tutorials/rekeying-function/ksql/code tutorial
-
-  - name: Deploy the site to staging
-    skip:
-      when: branch != 'master' AND branch !~ '.*staging.*'
-    task:
-      secrets:
-        - name: aws_credentials
-      prologue:
-        commands:
-          - checkout
-      jobs:
-        - name: Copy to S3
-          commands:
-            - cache restore site-$SEMAPHORE_GIT_SHA
-            - aws s3 cp --recursive ./_site "s3://kafka-tutorials-staging/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA/"
-            - echo "Deployed to http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA/"
-            - cache delete site-$SEMAPHORE_GIT_SHA

--- a/.semaphore/staging-site-deploy.yml
+++ b/.semaphore/staging-site-deploy.yml
@@ -1,0 +1,18 @@
+version: v1.0
+name: Kafka Tutorials staging site deployment
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - task:
+      secrets:
+        - name: aws_credentials
+      jobs:
+        - name: Compile and deploy site
+          commands:
+            - checkout
+            - cache restore site-$SEMAPHORE_GIT_SHA
+            - aws s3 cp --recursive ./_site "s3://kafka-tutorials-staging/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA/"
+            - echo "Deployed to http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/$SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA/"


### PR DESCRIPTION
In #136, we added automatic deployments from master and branches with "staging" in the name. This alters the CI-based preview site workflow to:
- only deploy automatically from master
- allow preview deployments to be created on-demand, using the the Semaphore UI:
![image](https://user-images.githubusercontent.com/141130/64800202-22d71180-d554-11e9-9fdb-f8b1b8fb4ba8.png)

Note: In the manual case, the `Promote` workflow must be invoked after completion of the `Build the website` block. This is because preview deployment reuses the cached site artifacts from the initial step.