### PR TITLE
Enforce checkstyle checks

### DIFF
--- a/_includes/tutorials/rekeying-function/ksql/code/Makefile
+++ b/_includes/tutorials/rekeying-function/ksql/code/Makefile
@@ -10,6 +10,7 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	mkdir -p $(TEST_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/rekeying-function/ksql.yml $(TEMP_DIR)
+	java -jar ../../../../../checkstyle/checkstyle-current-all.jar -c ../../../../../checkstyle/google_checks.xml $(TEMP_DIR)/rekey-with-function/
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-key-query.log) <(sort $(DEV_OUTPUTS_DIR)/key-query/output-0.log)"
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-query-rekeyed-stream.log) <(sort $(DEV_OUTPUTS_DIR)/query-rekeyed-stream/output-0.log)"
 	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-describe-function.log $(DEV_OUTPUTS_DIR)/describe-function/output-0.log"

--- a/_includes/tutorials/rekeying-function/ksql/code/src/main/java/io/confluent/developer/RegexReplace.java
+++ b/_includes/tutorials/rekeying-function/ksql/code/src/main/java/io/confluent/developer/RegexReplace.java
@@ -7,14 +7,24 @@ import io.confluent.ksql.function.udf.UdfParameter;
 @UdfDescription(name = "regexReplace", description = "Replace string using a regex")
 public class RegexReplace {
 
+  /**
+   * regexReplace string using a regex.
+   */
   @Udf(description = "regexReplace string using a regex")
   public String regexReplace(
-    @UdfParameter(value = "input", description = "If null, then function returns null.") final String input,
-    @UdfParameter(value = "regex", description = "If null, then function returns null.") final String regex,
-    @UdfParameter(value = "replacement", description = "If null, then function returns null.") final String replacement) {
-      if (input == null || regex == null || replacement == null) {
-        return null;
-      }  
-      return input.replaceAll(regex, replacement);
+      @UdfParameter(
+      value = "input",
+      description = "If null, then function returns null.") 
+      final String input,
+      @UdfParameter(value = "regex",
+      description = "If null, then function returns null.") 
+      final String regex,
+      @UdfParameter(value = "replacement",
+      description = "If null, then function returns null.") 
+      final String replacement) {
+    if (input == null || regex == null || replacement == null) {
+      return null;
+    }
+    return input.replaceAll(regex, replacement);
   }
 }

--- a/_includes/tutorials/rekeying-function/ksql/code/src/test/java/io/confluent/developer/RegexReplaceTest.java
+++ b/_includes/tutorials/rekeying-function/ksql/code/src/test/java/io/confluent/developer/RegexReplaceTest.java
@@ -1,24 +1,26 @@
 package io.confluent.developer;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import io.confluent.developer.RegexReplace;
 import org.junit.Test;
 
 public class RegexReplaceTest {
 
-    @Test
-    public void testRegexReplace() {
-        RegexReplace udf = new RegexReplace();
-        String regEx = "\\(?(\\d{3}).*";
-        assertEquals("206", udf.regexReplace("206-555-1272", regEx, "$1"));
-        assertEquals("425", udf.regexReplace("425.555.6940", regEx, "$1"));
-        assertEquals("360", udf.regexReplace("360 555 6952", regEx, "$1"));
-        assertEquals("253", udf.regexReplace("(253) 555-7050", regEx, "$1"));
-        assertEquals("425", udf.regexReplace("425-555-7926", regEx, "$1"));
+  @Test
+  public void testRegexReplace() {
+    RegexReplace udf = new RegexReplace();
+    String regEx = "\\(?(\\d{3}).*";
+    assertEquals("206", udf.regexReplace("206-555-1272", regEx, "$1"));
+    assertEquals("425", udf.regexReplace("425.555.6940", regEx, "$1"));
+    assertEquals("360", udf.regexReplace("360 555 6952", regEx, "$1"));
+    assertEquals("253", udf.regexReplace("(253) 555-7050", regEx, "$1"));
+    assertEquals("425", udf.regexReplace("425-555-7926", regEx, "$1"));
 
-        // test null parameters return null
-        assertNull(udf.regexReplace(null, regEx, "$1"));
-        assertNull(udf.regexReplace("425-555-7926", null, "$1"));
-        assertNull(udf.regexReplace("425-555-7926", regEx, null));
-    }
+    // test null parameters return null
+    assertNull(udf.regexReplace(null, regEx, "$1"));
+    assertNull(udf.regexReplace("425-555-7926", null, "$1"));
+    assertNull(udf.regexReplace("425-555-7926", regEx, null));
+  }
 }

--- a/_includes/tutorials/serialization/kstreams/code/Makefile
+++ b/_includes/tutorials/serialization/kstreams/code/Makefile
@@ -6,4 +6,5 @@ tutorial:
 	rm -r $(DEV_OUTPUTS_DIR) || true
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/serialization/kstreams.yml $(TEMP_DIR)
+	java -jar ../../../../../checkstyle/checkstyle-current-all.jar -c ../../../../../checkstyle/google_checks.xml $(TEMP_DIR)/kstreams-serialization/src/*
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/avro-movies.txt $(DEV_OUTPUTS_DIR)/avro-movies-actual.txt

--- a/_includes/tutorials/serialization/kstreams/code/src/main/java/io/confluent/developer/serialization/SerializationTutorial.java
+++ b/_includes/tutorials/serialization/kstreams/code/src/main/java/io/confluent/developer/serialization/SerializationTutorial.java
@@ -1,14 +1,14 @@
 package io.confluent.developer.serialization;
 
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Produced;
+import static java.lang.Integer.parseInt;
+import static java.lang.Short.parseShort;
+import static org.apache.kafka.common.serialization.Serdes.Long;
+import static org.apache.kafka.common.serialization.Serdes.String;
+
+import io.confluent.developer.avro.Movie;
+import io.confluent.developer.serialization.serde.MovieJsonSerde;
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -19,15 +19,15 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 
-import io.confluent.developer.avro.Movie;
-import io.confluent.developer.serialization.serde.MovieJsonSerde;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
-import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
-
-import static java.lang.Integer.parseInt;
-import static java.lang.Short.parseShort;
-import static org.apache.kafka.common.serialization.Serdes.Long;
-import static org.apache.kafka.common.serialization.Serdes.String;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
 
 public class SerializationTutorial {
 
@@ -38,7 +38,8 @@ public class SerializationTutorial {
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, envProps.getProperty("bootstrap.servers"));
     props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, String().getClass());
     props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, String().getClass());
-    props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, envProps.getProperty("schema.registry.url"));
+    props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+              envProps.getProperty("schema.registry.url"));
 
     return props;
   }
@@ -76,7 +77,9 @@ public class SerializationTutorial {
     return movieAvroSerde;
   }
 
-  protected Topology buildTopology(Properties envProps, final SpecificAvroSerde<Movie> movieSpecificAvroSerde) {
+  protected Topology buildTopology(
+      Properties envProps,
+      final SpecificAvroSerde<Movie> movieSpecificAvroSerde) {
     final String inputJsonTopicName = envProps.getProperty("input.json.movies.topic.name");
     final String outAvroTopicName = envProps.getProperty("output.avro.movies.topic.name");
 
@@ -128,6 +131,9 @@ public class SerializationTutorial {
     System.exit(0);
   }
 
+  /**
+   * Launch the tutorial.
+   */
   public static void main(String[] args) throws IOException {
     if (args.length < 1) {
       throw new IllegalArgumentException(

--- a/_includes/tutorials/serialization/kstreams/code/src/main/java/io/confluent/developer/serialization/serde/MovieJsonSerde.java
+++ b/_includes/tutorials/serialization/kstreams/code/src/main/java/io/confluent/developer/serialization/serde/MovieJsonSerde.java
@@ -2,17 +2,20 @@ package io.confluent.developer.serialization.serde;
 
 import com.google.gson.Gson;
 
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.serialization.Serializer;
+import io.confluent.developer.avro.Movie;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import io.confluent.developer.avro.Movie;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
 
 public class MovieJsonSerde extends Serdes.WrapperSerde<Movie> {
 
+  /**
+   * Wraps the Gson serialization of a Movie class.
+   */
   public MovieJsonSerde() {
     super(new Serializer<Movie>() {
       private Gson gson = new Gson();

--- a/_includes/tutorials/serialization/kstreams/code/src/test/java/io/confluent/developer/serialization/SerializationTutorialTest.java
+++ b/_includes/tutorials/serialization/kstreams/code/src/test/java/io/confluent/developer/serialization/SerializationTutorialTest.java
@@ -3,6 +3,18 @@ package io.confluent.developer.serialization;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
+import io.confluent.developer.avro.Movie;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
@@ -15,25 +27,16 @@ import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.apache.kafka.streams.test.OutputVerifier;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Properties;
-
-import io.confluent.developer.avro.Movie;
-import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
-
 public class SerializationTutorialTest {
 
-  private final static String TEST_CONFIG_FILE = "configuration/test.properties";
+  private static final String TEST_CONFIG_FILE = "configuration/test.properties";
 
-  private SpecificAvroSerde<Movie> makeAvroSerDe(Properties envProps) throws IOException, RestClientException {
+  private SpecificAvroSerde<Movie> makeAvroSerDe(
+      Properties envProps) throws IOException,
+      RestClientException {
 
-    // MockSchemaRegistryClient doesn't require connection to Schema Registry which is perfect for unit test
+    // MockSchemaRegistryClient doesn't require connection to Schema Registry which is perfect for
+    // unit test
     final MockSchemaRegistryClient client = new MockSchemaRegistryClient();
     String outputTopic = envProps.getProperty("output.avro.movies.topic.name");
     client.register(outputTopic + "-value", Movie.SCHEMA$);
@@ -42,7 +45,8 @@ public class SerializationTutorialTest {
     final HashMap<String, String> map = new HashMap<>();
 
     // this should be unnecessary because we use MockSchemaRegistryClient
-    // but still required in order to avoid `io.confluent.common.config.ConfigException: Missing required configuration "schema.registry.url" which has no default value.`
+    // but still required in order to avoid `io.confluent.common.config.ConfigException: 
+    // Missing required configuration "schema.registry.url" which has no default value.`
     map.put("schema.registry.url", envProps.getProperty("schema.registry.url"));
 
     movieAvroSerde.configure(map, false);
@@ -85,14 +89,18 @@ public class SerializationTutorialTest {
 
     for (int i = 0; i < 3; i++) {
       final ProducerRecord<Long, Movie>
-          actual =
-          testDriver.readOutput(outputTopic, keyDeserializer, movieSpecificAvroSerde.deserializer());
-      OutputVerifier.compareKeyValue(actual, new ProducerRecord<>(outputTopic, (long) i + 1, expectedMovies.get(i)));
+          actual = testDriver.readOutput(
+            outputTopic,
+            keyDeserializer,
+            movieSpecificAvroSerde.deserializer());
+      OutputVerifier.compareKeyValue(
+          actual,
+          new ProducerRecord<>(outputTopic, (long) i + 1, expectedMovies.get(i)));
     }
   }
 
   /**
-   * Prepares expected movies in avro format
+   * Prepares expected movies in avro format.
    *
    * @return a list of three (3) movie
    */
@@ -105,7 +113,7 @@ public class SerializationTutorialTest {
   }
 
   /**
-   * Prepares test data in JSON format
+   * Prepares test data in JSON format.
    *
    * @return a list of three (3) movies
    */

--- a/checkstyle/checkstyle-current-all.jar
+++ b/checkstyle/checkstyle-current-all.jar
@@ -1,0 +1,1 @@
+checkstyle-8.24-all.jar

--- a/checkstyle/google_checks.xml
+++ b/checkstyle/google_checks.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format"
+             value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message"
+             value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens"
+             value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlySame"/>
+            <property name="tokens"
+             value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="option" value="alone"/>
+            <property name="tokens"
+             value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+            <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapDot"/>
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapComma"/>
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapEllipsis"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LambdaParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+            <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+            <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="2"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens"
+             value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
+        <module name="ParenPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens"
+             value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationMostCases"/>
+            <property name="tokens"
+             value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationVariables"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments"
+             value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target"
+             value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+    </module>
+</module>


### PR DESCRIPTION
From issue #67 - checkstyled code will be more consistent across tutorials.  As an experiment I've added checkstyle checks to two tutorials `rekey-with-function/ksql` and `changing-serialization-format/kstreams`.  This is just at an experimental stage and totally up for debate.

In a nutshell what this change does:
 * added `checkstyle/checkstyle-8.24-all.jar` and soft linked to `checkstyle/checkstyle-current-all.jar`.
 * added `checkstyle/google_checks.xml` - copied from the the checkstyle [git repo](https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-8.24/src/main/resources/google_checks.xml) with one change `<property name="severity" value="error"/>`.  The checkstyle command line tool only increments the exit code for errors, not warnings, and we want a warning to break the build.
 * with this in place I can run a checkstyle command in the `Makefile` for a tutorial
   
   ``` bash
   java -jar ../../../../../checkstyle/checkstyle-current-all.jar -c ../../../../../checkstyle/google_checks.xml $(TEMP_DIR)/kstreams-serialization/src/*
   ```

It's definitely worth having a conversation about the checkstyle rules and suppressions that would be wanted.