### PR TITLE
Repairs some common typos

### DIFF
--- a/_includes/tutorials/joining-stream-table/kstreams/markup/test/make-topology-test.adoc
+++ b/_includes/tutorials/joining-stream-table/kstreams/markup/test/make-topology-test.adoc
@@ -1,4 +1,4 @@
-Now create the following file at `src/test/java/io/confluent/developer/JoinStreamToTableTest.java`. Testing a Kafka streams application requies a bit of test harness code, but happily the `org.apache.kafka.streams.TopologyTestDriver` class makes this much more pleasant that it would otherwise be.
+Now create the following file at `src/test/java/io/confluent/developer/JoinStreamToTableTest.java`. Testing a Kafka streams application requires a bit of test harness code, but happily the `org.apache.kafka.streams.TopologyTestDriver` class makes this much more pleasant that it would otherwise be.
 
 There is only one method in `JoinStreamToTableTest` annotated with `@Test`, and that is `testJoin()`. This method actually runs our Streams topology using the `TopologyTestDriver` and some mocked data that is set up inside the test method.
 

--- a/_includes/tutorials/transforming/kstreams/markup/test/make-test.adoc
+++ b/_includes/tutorials/transforming/kstreams/markup/test/make-test.adoc
@@ -1,4 +1,4 @@
-Create the following test file at `src/test/java/io/confluent/developer/TransformStreamTest.java`. Testing a Kafka streams application requies a bit of test harness code, but happily the `org.apache.kafka.streams.TopologyTestDriver` class makes this much more pleasant that it would otherwise be.
+Create the following test file at `src/test/java/io/confluent/developer/TransformStreamTest.java`. Testing a Kafka streams application requires a bit of test harness code, but happily the `org.apache.kafka.streams.TopologyTestDriver` class makes this much more pleasant that it would otherwise be.
 
 There are two methods in `TransformStreamTest` annotated with `@Test`: `testMovieConverter()` and `testTransformStream()`. `testMovieConverter()` is a simple method that tests the string that is core to the transformation action of this Streams application. `testMovieConverter()` actually runs our Streams topology using the `TopologyTestDriver` and some mocked data that is set up inside the test method.
 

--- a/_includes/tutorials/tumbling-windows/kstreams/markup/test/make-topology-test.adoc
+++ b/_includes/tutorials/tumbling-windows/kstreams/markup/test/make-topology-test.adoc
@@ -1,4 +1,4 @@
-Now create the following file at `src/test/java/io/confluent/developer/TumblingWindowTest.java`. Testing a Kafka streams application requies a bit of test harness code, but the `org.apache.kafka.streams.TopologyTestDriver` class makes this easy.
+Now create the following file at `src/test/java/io/confluent/developer/TumblingWindowTest.java`. Testing a Kafka streams application requires a bit of test harness code, but the `org.apache.kafka.streams.TopologyTestDriver` class makes this easy.
 
 There is only one method in `TumblingWindowTest` annotated with `@Test`, and that is `testWindows()`. This method actually runs our Streams topology using the `https://kafka.apache.org/{{ site.ak_javadoc_version }}/javadoc/org/apache/kafka/streams/TopologyTestDriver.html[TopologyTestDriver]` and some mocked data that is set up inside the test method.
 


### PR DESCRIPTION
Various copy and pasting resulted in `requires` misspelled in a few places.