### PR TITLE
Reduce CI flakiness and add execution timeout

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,6 +38,8 @@ blocks:
             - cache store site-$SEMAPHORE_GIT_SHA _site
 
   - name: Run the tests
+    execution_time_limit:
+      minutes: 15
     task:
       prologue:
         commands:

--- a/harness_runner/harness_runner.py
+++ b/harness_runner/harness_runner.py
@@ -127,6 +127,7 @@ def run_steps(harness, temp_dir, sequence):
     finally:
         for name, proc in context["procs"].items():
             kill_async_process(proc)
+        time.sleep(5)
 
 def execute(file_name, temp_dir, sequence="dev, test, prod"):
     harness = load_file(file_name)


### PR DESCRIPTION
Adding a sleep in the harness runner works around an apparent race condition cleaning up the test containers when running tests on Semaphore. cf. https://github.com/confluentinc/kafka-tutorials/pull/144#issuecomment-569727611

This also adds a ceiling on CI test execution time.