### PR TITLE
Change Apache Kafka explanation from Messaging to Streaming Platform

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,10 @@
         <div class="container">
           <div class="headline">
             <h1>
-              Say Hello World to event streaming.
+              Say Hello World to Event Streaming.
             </h1>
 
-            <h2 class="subtitle">Apache Kafka is a powerful, scalable, fault-tolerant publish-subscribe messaging system. This site features full code examples using Kafka, Kafka Streams, and KSQL to demonstrate real use cases.</h2>
+            <h2 class="subtitle">Apache Kafka is a powerful, scalable, fault-tolerant distributed streaming platform. This site features full code examples using Kafka, Kafka Streams, and KSQL to demonstrate real use cases.</h2>
           </div>
         </div>
       </div>


### PR DESCRIPTION
According to the [Apache Kafka official site](https://kafka.apache.org/), the technology is known for being a distributed streaming platform, rather than just a pub/sub messaging system.

![image](https://user-images.githubusercontent.com/35476/72022062-90165d00-323d-11ea-9050-55d7caa2d1b5.png)

Therefore, this PR corrects the description of the index.html page.