### PR TITLE
Fixing KSQL Hopping Window 'Print Topic' Narrative

### DIFF
--- a/_includes/tutorials/hopping-windows/ksql/markup/dev/print-topic.adoc
+++ b/_includes/tutorials/hopping-windows/ksql/markup/dev/print-topic.adoc
@@ -4,7 +4,7 @@ Finally, let's see what's available on the underlying Kafka topic for the table.
 <pre class="snippet"><code class="sql">{% include_raw tutorials/hopping-windows/ksql/code/tutorial-steps/dev/print-topic.sql %}</code></pre>
 +++++
 
-Notice that the key for each message contains some strange characters that aren't quite printable. KSQL has combined the grouping key (movie title) with its window boundaries using a format that's not quite printable in this format. It should look something like this:
+The output should look similar to:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/hopping-windows/ksql/code/tutorial-steps/dev/outputs/print-topic/output-0.log %}</code></pre>


### PR DESCRIPTION
This PR fixes a small mistake left behind in the `KSQL Hopping Window` tutorial where a non-sense paragraph was left behind and causes confusion for the reader.

Thanks,

-- Ricardo