### PR TITLE
Correction to KT name for  (#221)

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
             <div>Connect data sources & sinks.</div>
           </div>
           <ul>
-            <li><a href="connect-jdbc-kstreams-rekey-specificavro/kstreams.html">Key a stream with transformations</a></li>
+            <li><a href="connect-jdbc-kstreams-rekey-specificavro/kstreams.html">Key a stream in the app</a></li>
           </ul>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
             <div>Connect data sources & sinks.</div>
           </div>
           <ul>
-            <li><a href="connect-jdbc-kstreams-rekey-specificavro/kstreams.html">Key a stream in the app</a></li>
+            <li><a href="connect-jdbc-kstreams-rekey-specificavro/kstreams.html">Add a key to a stream from a JDBC source</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
This PR is a correction to https://github.com/confluentinc/kafka-tutorials/pull/221

The Tutorial is mostly fine but the name that shows up in the card is wrong.

The reason I messed this up: both KTs that I intended to write (#122 and #123) use SMTs, `setschemametadata`.  But the one I wrote so far doesn't use SMTs for rekey.  The file names are correct `connect-jdbc-kstreams-rekey-specificavro`, but when I saw the SMT, I mislabelled it as the SMT rekeyer