### PR TITLE
Add Confluent Developer to site navigation

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,6 +41,7 @@
           <li><a href="https://www.confluent.io/online-talks/">Online Talk</a></li>
           <li><a href="https://www.confluent.io/apache-kafka-meetups/">Meetups</a></li>
           <li><a href="https://kafka-summit.org/">Kafka Summit</a></li>
+          <li><a href="https://developer.confluent.io/">Confluent Developer</a></li>
           <li><a href="https://docs.confluent.io/current">Docs</a></li>
           <li><a href="https://www.confluent.io/blog/">Blog</a></li>
         </ul>
@@ -85,7 +86,7 @@
       </div>
     </div>
     <div class="copyright">
-      <p>Copyright © Confluent, Inc. 2019.&nbsp;<a href="https://www.confluent.io/privacy">Privacy Policy</a> | <a href="https://www.confluent.io/terms-of-use">Terms &amp; Conditions</a> | <a href="https://www.confluent.io/modern-slavery-policy">Modern Slavery Policy</a></p>
+      <p>Copyright © Confluent, Inc. 2020.&nbsp;<a href="https://www.confluent.io/privacy">Privacy Policy</a> | <a href="https://www.confluent.io/terms-of-use">Terms &amp; Conditions</a> | <a href="https://www.confluent.io/modern-slavery-policy">Modern Slavery Policy</a></p>
     </div>
   </div>
 </footer>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,16 +2,31 @@
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager_id }}" height="0"
     width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-<nav>
+<div class="nav-company has-text-centered has-background-black is-uppercase">
+  <a class="has-text-white" target="_blank" href="https://confluent.io">Go to confluent.io</a>
+</div>
+<nav class="navbar">
   <div class="container">
-    <div>
-      <a href="{{ "/" | relative_url }}">
+    <div class="navbar-brand">
+      <a class="navbar-item" href="{{ "/" | relative_url }}">
         <img class="logo" src="{{ "/assets/img/logo.svg" | relative_url }}" alt="Confluent" />
+        <svg class="sub-domain" xmlns="http://www.w3.org/2000/svg" width="150" height="32" viewBox="0 0 180 29"><g fill="none" fill-rule="evenodd"><rect width="100%" height="100%" fill="#F3F4F7" rx="5"></rect><text fill="#000" font-family="Roboto" font-size="17.037" font-weight="bold" letter-spacing=".7"><tspan x="11" y="21">KAFKA TUTORIALS</tspan></text></g></svg>
+      </a>
+      <a class="navbar-burger">
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
       </a>
     </div>
-    <div class="join">
-      <p>Join the Community. Contribute a tutorial.</p>
-      <a class="cta-button primary" href="{{ site.contribute_url }}">Contribute <span>a tutorial</span></a>
+    <div class="navbar-menu is-uppercase">
+      <div class="navbar-end">
+        <div class="navbar-item">
+          <a class="link" href="https://developer.confluent.io">Confluent Developer</a>
+        </div>
+        <div class="navbar-item">
+          <a class="cta" href="{{ site.contribute_url }}"><span class="icon"><i class="fab fa-github"></i></span><span>Contribute</span></a>
+        </div>
+      </div>
     </div>
   </div>
 </nav>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -37,4 +37,10 @@ $(function() {
 
         return false;
     });
+
+    $('.navbar-burger').on('click', function(e) {
+        e.preventDefault();
+        $('.navbar-burger').toggleClass('is-active');
+        $('.navbar-menu').toggleClass('is-active');
+    });
 });

--- a/assets/js/tutorial.js
+++ b/assets/js/tutorial.js
@@ -49,4 +49,11 @@ $(document).ready(function() {
   $(".cflt-options select").on("change", function() {
     window.location.href = this.value;
   });
+
+
+  $('.navbar-burger').on('click', function(e) {
+    e.preventDefault();
+    $('.navbar-burger').toggleClass('is-active');
+    $('.navbar-menu').toggleClass('is-active');
+  });
 });

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -15,11 +15,6 @@ button {
   font-family: "MarkOT";
 }
 
-.logo {
-  height: 33px;
-  width: auto;
-}
-
 .card-cta {
 
 .cta-button {
@@ -52,52 +47,73 @@ body {
   background: #f9f9fa;
   font-size: 14px;
   line-height: 1;
+}
 
-  nav {
-    padding-top: 15px;
-    padding-bottom: 15px;
-    background: #fff;
+.nav-company {
+    padding: 10px;
 
-    .container {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
+    a {
+        font-size: 10px;
+        letter-spacing: 1.17px;
+        font-weight: 600;
+        line-height: 20px;
 
-      @media (max-width: 1087px) {
-        margin: 0 20px;
-      }
-
-      > div:first-child {
-        @media (max-width: 480px) {
-          width: 45%;
-        }
-      }
-
-      .join {
-        p {
-          display: inline-block;
-          font-size: 14px;
-          font-weight: 500;
-          color: $baseColor;
-          margin-right: 10px;
-
-          @media (max-width: 640px) {
-            display: none;
-          }
-        }
-
-        .cta-button {
-          span {
-            display: none;
-
-            @media (min-width: 370px) and (max-width: 640px) {
-              display: inline-block;
-            }
-          }
-        }
-      }
+        &:hover { text-decoration: underline; }
     }
-  }
+}
+
+.navbar {
+    margin: 0 25px;
+    background: none;
+    padding: 18px 0;
+
+    .navbar-brand .navbar-item {
+        padding: 0;
+        .logo {
+            max-height: none;
+            height: 39px;
+            width: auto;
+            margin-right: 10px;
+        }
+
+    }
+
+    .navbar-burger span { height: 2px; }
+
+    .navbar-menu .navbar-item {
+        color: #222;
+        font-size: 14px;
+        font-weight: 400;
+        letter-spacing: .7px;
+        margin: 20px;
+        padding: 0;
+        a {
+            color: inherit;
+            padding: 2px 0;
+        }
+
+        @media screen and (min-width: 1079px) {
+            margin: 0 20px;
+
+            .link {
+                margin-top: 2px;
+                color: inherit;
+                border-bottom: 5px solid transparent;
+                &:hover { border-color: #b78142; }
+            }
+
+            .cta {
+                background-color: #38cced;
+                color: #fff;
+                border-radius: 6px;
+                padding: 12px 30px 10px 30px;
+                margin-right: 0;
+                border: none;
+
+                .icon { display: inline-block; }
+            }
+        }
+    }
 }
 
 .snippet-wrapper {


### PR DESCRIPTION
Adds links to Confluent Developer and the main Confluent home in the site nav. Restyles the contribute link.

![image](https://user-images.githubusercontent.com/141130/77329101-dedb7b00-6cf3-11ea-8cf7-df106d91c422.png)

On smaller screens, these links are rendered in a hamburger menu.

![image](https://user-images.githubusercontent.com/141130/77329521-7771fb00-6cf4-11ea-86cc-09beaf0903de.png)


Closes #293 