### PR TITLE
DEVX-1701: Make sure gradle procs closed

### DIFF
--- a/_data/harnesses/connect-add-key-to-source/kstreams.yml
+++ b/_data/harnesses/connect-add-key-to-source/kstreams.yml
@@ -197,3 +197,8 @@ prod:
         - action: skip
           render:
             file: tutorials/connect-add-key-to-source/kstreams/markup/prod/launch-container.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/clean-up.sh
+          render:
+            skip: true    

--- a/_includes/tutorials/aggregating-average/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-average/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/aggregating-sum/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/src/main/java/io/confluent/developer/connect/jdbc/specificavro/StreamsIngest.java
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/src/main/java/io/confluent/developer/connect/jdbc/specificavro/StreamsIngest.java
@@ -15,6 +15,7 @@ import org.apache.kafka.streams.kstream.Produced;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -116,7 +117,7 @@ public class StreamsIngest {
     Runtime.getRuntime().addShutdownHook(new Thread("streams-shutdown-hook") {
       @Override
       public void run() {
-        streams.close();
+        streams.close(Duration.ofSeconds(5));
         latch.countDown();
       }
     });

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down && docker rm -f $(docker ps -q --filter name=sqlitekt)
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,3 +1,4 @@
 docker-compose down
 
 pkill -f ".*gradle.*"
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,4 +1,3 @@
 docker-compose down
 
 pkill -f ".*gradle.*"
-pkill -f ".*gradle.*"

--- a/_includes/tutorials/filtering/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/filtering/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/finding-distinct/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/finding-distinct/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/fk-joins/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/fk-joins/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/joining-stream-table/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/merging/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/merging/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/serialization/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/serialization/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/splitting/kstreams/code/src/main/java/io/confluent/developer/SplitStream.java
+++ b/_includes/tutorials/splitting/kstreams/code/src/main/java/io/confluent/developer/SplitStream.java
@@ -14,6 +14,7 @@ import org.apache.kafka.streams.kstream.KStream;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 
@@ -106,7 +107,7 @@ public class SplitStream {
         Runtime.getRuntime().addShutdownHook(new Thread("streams-shutdown-hook") {
             @Override
             public void run() {
-                streams.close();
+                streams.close(Duration.ofSeconds(5));
                 latch.countDown();
             }
         });

--- a/_includes/tutorials/splitting/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/splitting/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/transforming/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/transforming/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"

--- a/_includes/tutorials/window-final-result/kstreams/code/tutorial-steps/prod/clean-up.sh
+++ b/_includes/tutorials/window-final-result/kstreams/code/tutorial-steps/prod/clean-up.sh
@@ -1,1 +1,2 @@
 docker-compose down
+pkill -f ".*gradle.*"


### PR DESCRIPTION
During test harness execution for kstream Kafka Tutorials, the Gradle process will persist running when the test harness job completes, which seems to indirectly cause a test failure.  The test itself will pass, but since the process prevents the job from exiting, it times out, creating a failure.