### PR TITLE
Hotfix subdomain tag font

### DIFF
--- a/_includes/vendors.html
+++ b/_includes/vendors.html
@@ -1,3 +1,4 @@
 {% if jekyll.environment == "production" %}
     {% include vendors/gtag.html %}
 {% endif %}
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet">


### PR DESCRIPTION
This includes Roboto with a link rel. This ensures it renders correctly on machines where Roboto is not locally-installed.

preview
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/master/cccc971aee02015dcc1a44545012c99954b213d0/