### PR TITLE
add print topic step to deserialization error tutorial

### DIFF
--- a/_data/harnesses/deserialization-errors/ksql.yml
+++ b/_data/harnesses/deserialization-errors/ksql.yml
@@ -78,6 +78,9 @@ dev:
             - file: tutorial-steps/dev/check-errors-query.sql
               render:
                 file: tutorials/deserialization-errors/ksql/markup/dev/check-errors-query.adoc
+            - file: tutorial-steps/dev/print-topic.sql
+              render:
+                file: tutorials/deserialization-errors/ksql/markup/dev/print-topic.adoc
           stdout:
             directory: tutorial-steps/dev/outputs
 

--- a/_includes/tutorials/deserialization-errors/ksql/code/Makefile
+++ b/_includes/tutorials/deserialization-errors/ksql/code/Makefile
@@ -11,4 +11,5 @@ tutorial:
 	mkdir -p $(TEST_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/deserialization-errors/ksql.yml $(TEMP_DIR)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-query.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
+	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log)) <(sort <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log))"
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-check-errors-query.log $(DEV_OUTPUTS_DIR)/check-errors-query/output-0.log

--- a/_includes/tutorials/deserialization-errors/ksql/code/Makefile
+++ b/_includes/tutorials/deserialization-errors/ksql/code/Makefile
@@ -11,5 +11,5 @@ tutorial:
 	mkdir -p $(TEST_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/deserialization-errors/ksql.yml $(TEMP_DIR)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-query.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
-	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log)) <(sort <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log))"
+	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 6- $(STEPS_DIR)/dev/expected-print.log)) <(sort <(cut -d ',' -f 6- $(DEV_OUTPUTS_DIR)/print-topic/output-0.log))"
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-check-errors-query.log $(DEV_OUTPUTS_DIR)/check-errors-query/output-0.log

--- a/_includes/tutorials/deserialization-errors/ksql/code/tutorial-steps/dev/expected-print.log
+++ b/_includes/tutorials/deserialization-errors/ksql/code/tutorial-steps/dev/expected-print.log
@@ -1,0 +1,3 @@
+Key format: UNDEFINED
+Value format: JSON
+rowtime: 5/5/20 9:32:02 AM UTC, key: <null>, value: {"level":"ERROR","logger":"processing.CSAS_SENSORS_0.KsqlTopic.Source.deserializer","time":1588671122813,"message":{"type":0,"deserializationError":{"errorMessage":"mvn value from topic: SENSORS_RAW","recordB64":"eyJpZCI6ICIxYTA3NmE2NC00YTg0LTQwY2ItYTJlOC0yMTkwZjNiMzc0NjUiLCAidGltZXN0YW1wIjogIjIwMjAtMDEtMTUgMDI6MzA6MzAiLCAiZW5hYmxlZCI6ICJ0cnVlIn0=","cause":["Can't convert type. sourceType: TextNode, requiredType: BOOLEAN, path: $.ENABLED","Can't convert type. sourceType: TextNode, requiredType: BOOLEAN, path: .ENABLED","Can't convert type. sourceType: TextNode, requiredType: BOOLEAN"]},"recordProcessingError":null,"productionError":null}}

--- a/_includes/tutorials/deserialization-errors/ksql/markup/dev/print-topic.adoc
+++ b/_includes/tutorials/deserialization-errors/ksql/markup/dev/print-topic.adoc
@@ -8,7 +8,7 @@ Print the contents of its underlying topic to see some more.
 The output should look similar to:
 
 +++++
-<pre class="snippet"><code class="shell">{% include_raw tutorials/deserialization-errors/ksql/code/tutorial-steps/dev/outputs/print-topic/output-0.log %}</code></pre>
+<pre class="snippet"><code class="shell">{% include_raw tutorials/deserialization-errors/ksql/code/tutorial-steps/dev/expected-print.log %}</code></pre>
 +++++
 
 Note the presence of a field called `recordB64`.


### PR DESCRIPTION
When making some other changes in here I noticed that the existing `print-topic.adoc` file was not hooked up in the tutorial's yaml file.

I've added it in here and ensured the print topic output is tested.  Alternatively, if we don't want the print topic step I can just delete the file and associated scripts.

Thoughts?