### PR TITLE
MINOR: Remove use of '/usr/bin' from docker-compose commands

### DIFF
--- a/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/create-topic.sh
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker /usr/bin/kafka-topics --create --topic example-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1
+docker-compose exec broker kafka-topics --create --topic example-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer-from-beginning.sh
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer-from-beginning.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker /usr/bin/kafka-console-consumer --topic example-topic --bootstrap-server broker:9092  --from-beginning --max-messages 8
+docker-compose exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092  --from-beginning --max-messages 8

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker /usr/bin/kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 \
+docker-compose exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 \
  --from-beginning \
  --property print.key=true \
  --property key.separator="-" \

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker /usr/bin/kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 --max-messages 4
+docker-compose exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 --max-messages 4

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-producer-keys.sh
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-producer-keys.sh
@@ -1,3 +1,3 @@
-docker-compose exec -T broker /usr/bin/kafka-console-producer --topic example-topic --broker-list broker:9092\
+docker-compose exec -T broker kafka-console-producer --topic example-topic --broker-list broker:9092\
   --property parse.key=true\
   --property key.separator=":"

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-producer.sh
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/harness-console-producer.sh
@@ -1,1 +1,1 @@
-docker-compose exec -T broker /usr/bin/kafka-console-producer --topic example-topic --broker-list broker:9092
+docker-compose exec -T broker kafka-console-producer --topic example-topic --broker-list broker:9092


### PR DESCRIPTION
A minor PR to have consistent use of `docker-compose` commands in the 101 tutorials