### PR TITLE
Fix 2-by-1 aspect ratio for embedded media

### DIFF
--- a/assets/sass/tutorial.scss
+++ b/assets/sass/tutorial.scss
@@ -146,11 +146,22 @@
   }
 
   .tutorial-media-container {
-    margin-top: 60px;
-    iframe {
-      width:100%;
-      height:331px;
-    }
+      margin-top: 60px;
+
+      .image {
+          position: relative;
+          height: 0;
+          overflow: hidden;
+          padding-bottom: 50%;
+
+          iframe {
+              position: absolute;
+              top: 0;
+              left: 0;
+              width: 100%;
+              height: 100%;
+          }
+      }
   }
 
   @media screen and (max-width: 640px) {


### PR DESCRIPTION
iframe aspect ratio remains consistent at all screen widths, so there is no letterboxing effect:
![kt-ar](https://user-images.githubusercontent.com/141130/84214865-a34e8280-aa92-11ea-9d0a-3f6b177ab370.gif)
