### PR TITLE
Update KSQL rekeyed expected-print-output

### DIFF
--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-output.log
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-output.log
@@ -1,6 +1,7 @@
-Key format: KAFKA_INT
+Key format: KAFKA_INT or KAFKA_STRING
 Value format: AVRO
 rowtime: 2020/05/04 23:24:30.376 Z, key: 294, value: {"RATING": 8.2}
+Key format: KAFKA_INT
 rowtime: 2020/05/04 23:24:30.684 Z, key: 354, value: {"RATING": 9.9}
 rowtime: 2020/05/04 23:24:30.781 Z, key: 354, value: {"RATING": 9.7}
 rowtime: 2020/05/04 23:24:30.949 Z, key: 782, value: {"RATING": 7.7}


### PR DESCRIPTION
ksqlDB 0.11 [test](https://confluentinc.semaphoreci.com/jobs/c1d78f35-671a-4287-9aa9-e7b3ad9b3a39) failed:
```

bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- tutorial-steps/dev/expected-print-output.log\|sort) <(cut -d ',' -f 2- tutorial-steps/dev/outputs/print-output-topic/output-0.log\|sort)"
--
231 | 10a11
232 | > Key format: KAFKA_INT or KAFKA_STRING
234 | Makefile:8: recipe for target 'tutorial' failed


```