### PR TITLE
MINOR: Adding reset to all Makefiles

### DIFF
--- a/_includes/tutorials/aggregating-average/kstreams/code/Makefile
+++ b/_includes/tutorials/aggregating-average/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/aggregating-average/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-outputs.json $(DEV_OUTPUTS_DIR)/actual-outputs.json
+	reset

--- a/_includes/tutorials/aggregating-count/ksql/code/Makefile
+++ b/_includes/tutorials/aggregating-count/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-transient-query.log) <(sort $(DEV_OUTPUTS_DIR)/transient-query/output-0.log)"
 	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-output-topic.log)) <(sort <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log))"
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/test/expected-results.log) <(sort $(TEST_OUTPUTS_DIR)/test-results.log)"
+	reset

--- a/_includes/tutorials/aggregating-count/kstreams/code/Makefile
+++ b/_includes/tutorials/aggregating-count/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/aggregating-count/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.json $(DEV_OUTPUTS_DIR)/actual-output-events.json
+	reset

--- a/_includes/tutorials/aggregating-minmax/ksql/code/Makefile
+++ b/_includes/tutorials/aggregating-minmax/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-transient-query.log) <(sort $(DEV_OUTPUTS_DIR)/transient-query/output-0.log)"
 	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-output-topic.log)) <(sort <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log))"
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/test/expected-results.log) <(sort $(TEST_OUTPUTS_DIR)/test-results.log)"
+	reset

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/Makefile
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir -p $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/aggregating-minmax/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.json $(DEV_OUTPUTS_DIR)/actual-output-events.json
+	reset

--- a/_includes/tutorials/aggregating-sum/ksql/code/Makefile
+++ b/_includes/tutorials/aggregating-sum/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-transient.log) <(sort $(DEV_OUTPUTS_DIR)/transient-query/output-0.log)"
 	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log)) <(sort <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log))"
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/test/expected-results.log) <(sort $(TEST_OUTPUTS_DIR)/test-results.log)"
+	reset

--- a/_includes/tutorials/aggregating-sum/kstreams/code/Makefile
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/aggregating-sum/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.json $(DEV_OUTPUTS_DIR)/actual-output-events.json
+	reset

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/Makefile
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/Makefile
@@ -15,3 +15,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/test/expected-data-from-topic1-partition-0.sh $(TEST_OUTPUTS_DIR)/actual-output-topic1-partition-0.txt"
 	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/test/expected-data-from-topic2-partition-0.sh $(TEST_OUTPUTS_DIR)/actual-output-topic2-partition-0.txt"
 	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/test/expected-data-from-topic2-partition-1.sh $(TEST_OUTPUTS_DIR)/actual-output-topic2-partition-1.txt"
+	reset

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/Makefile
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/cogrouping-streams/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output.json $(DEV_OUTPUTS_DIR)/actual-output.json
+	reset

--- a/_includes/tutorials/connect-add-key-to-source/kafka/code/Makefile
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 
 
 
+	reset

--- a/_includes/tutorials/connect-add-key-to-source/ksql/code/Makefile
+++ b/_includes/tutorials/connect-add-key-to-source/ksql/code/Makefile
@@ -15,3 +15,4 @@ tutorial:
 	bash -c "diff --ignore-all-space --strip-trailing-cr <(cat $(STEPS_DIR)/dev/create-table_expected.log|tr '-' ' ') $(DEV_OUTPUTS_DIR)/create-table/output-0.log"
 	bash -c "diff --ignore-all-space --strip-trailing-cr $(STEPS_DIR)/dev/query-table_expected.log $(DEV_OUTPUTS_DIR)/query-table/output-1.log"
 	bash -c "diff --strip-trailing-cr <(sed 's/^.*key/key/' $(STEPS_DIR)/dev/consume-topic_expected.log) <(sed 's/^.*key/key/' $(DEV_OUTPUTS_DIR)/consume-topic/output-0.log)"
+	reset

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/Makefile
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/Makefile
@@ -9,3 +9,4 @@ tutorial:
 	harness-runner ../../../../../_data/harnesses/connect-add-key-to-source/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-input-events.log <(tail -6 $(DEV_OUTPUTS_DIR)/actual-input-events.log)"
 	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.log <(tail -6 $(DEV_OUTPUTS_DIR)/actual-output-events.log)"
+	reset

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/Makefile
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/Makefile
@@ -12,3 +12,4 @@ tutorial:
 
 
 
+	reset

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/code/Makefile
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/code/Makefile
@@ -13,3 +13,4 @@ tutorial:
 
 
 
+	reset

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/Makefile
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/Makefile
@@ -13,3 +13,4 @@ tutorial:
 
 
 
+	reset

--- a/_includes/tutorials/deserialization-errors/ksql/code/Makefile
+++ b/_includes/tutorials/deserialization-errors/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-query.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
 	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 6- $(STEPS_DIR)/dev/expected-print.log)) <(sort <(cut -d ',' -f 6- $(DEV_OUTPUTS_DIR)/print-topic/output-0.log))"
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-check-errors-query.log $(DEV_OUTPUTS_DIR)/check-errors-query/output-0.log
+	reset

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/Makefile
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/Makefile
@@ -8,4 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/dynamic-output-topic/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output.json $(DEV_OUTPUTS_DIR)/actual-output.json
-	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-special-output.json $(DEV_OUTPUTS_DIR)/actual-special-order-output.json
+	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-special-output.json $(DEV_OUTPUTS_DIR)/actual-special-order-output.json	reset

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/Makefile
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/Makefile
@@ -8,4 +8,5 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/dynamic-output-topic/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output.json $(DEV_OUTPUTS_DIR)/actual-output.json
-	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-special-output.json $(DEV_OUTPUTS_DIR)/actual-special-order-output.json	reset
+	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-special-output.json $(DEV_OUTPUTS_DIR)/actual-special-order-output.json	
+	reset

--- a/_includes/tutorials/filtering/ksql/code/Makefile
+++ b/_includes/tutorials/filtering/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/filtering/kstreams/code/Makefile
+++ b/_includes/tutorials/filtering/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/filtering/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.json $(DEV_OUTPUTS_DIR)/actual-output-events.json
+	reset

--- a/_includes/tutorials/finding-distinct/ksql/code/Makefile
+++ b/_includes/tutorials/finding-distinct/ksql/code/Makefile
@@ -13,3 +13,4 @@ tutorial:
 	harness-runner ../../../../../_data/harnesses/finding-distinct/ksql.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-window.log $(DEV_OUTPUTS_DIR)/transient-window/output-0.log
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-query.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
+	reset

--- a/_includes/tutorials/finding-distinct/kstreams/code/Makefile
+++ b/_includes/tutorials/finding-distinct/kstreams/code/Makefile
@@ -20,3 +20,4 @@ tutorial:
 	make --no-print-directory create-outputs-dir
 	make --no-print-directory run-harness
 	make --no-print-directory diff
+	reset

--- a/_includes/tutorials/fk-joins/kstreams/code/Makefile
+++ b/_includes/tutorials/fk-joins/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/fk-joins/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.json $(DEV_OUTPUTS_DIR)/music-interest.json
+	reset

--- a/_includes/tutorials/flatten-nested-data/ksql/code/Makefile
+++ b/_includes/tutorials/flatten-nested-data/ksql/code/Makefile
@@ -13,3 +13,4 @@ tutorial:
 	harness-runner ../../../../../_data/harnesses/flatten-nested-data/ksql.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-flattening.log $(DEV_OUTPUTS_DIR)/transient-flattening/output-0.log
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-query.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
+	reset

--- a/_includes/tutorials/hopping-windows/ksql/code/Makefile
+++ b/_includes/tutorials/hopping-windows/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-window.log $(DEV_OUTPUTS_DIR)/transient-window/output-0.log
 	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-topic.log)) <(sort <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-topic/output-0.log))"
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-query.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
+	reset

--- a/_includes/tutorials/joining-stream-stream/ksql/code/Makefile
+++ b/_includes/tutorials/joining-stream-stream/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr <(cat $(STEPS_DIR)/dev/expected-transient.log | sort) <(cat $(DEV_OUTPUTS_DIR)/transient-join/output-0.log | sort)"
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log | sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log | sort)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/joining-stream-table/ksql/code/Makefile
+++ b/_includes/tutorials/joining-stream-table/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient.log $(DEV_OUTPUTS_DIR)/transient-join/output-0.log
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/joining-stream-table/kstreams/code/Makefile
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/joining-stream-table/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.json $(DEV_OUTPUTS_DIR)/rated-movies.json
+	reset

--- a/_includes/tutorials/joining-table-table/ksql/code/Makefile
+++ b/_includes/tutorials/joining-table-table/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient.log $(DEV_OUTPUTS_DIR)/transient-join/output-0.log
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/kafka-connect-datagen-local/kafka/code/Makefile
+++ b/_includes/tutorials/kafka-connect-datagen-local/kafka/code/Makefile
@@ -10,3 +10,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr <(head -n1 $(STEPS_DIR)/dev/create-connector_expected.log) <(head -n1 $(DEV_OUTPUTS_DIR)/create-connector.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/check-connector_expected.log $(DEV_OUTPUTS_DIR)/check-connector.log
 	grep "Processed a total of 10 messages" $(DEV_OUTPUTS_DIR)/consume-topic.log
+	reset

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/Makefile
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/Makefile
@@ -7,3 +7,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/kafka-consumer-application/kafka.yml $(TEMP_DIR)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output.txt $(DEV_OUTPUTS_DIR)/actual-output.txt
+	reset

--- a/_includes/tutorials/merging/ksql/code/Makefile
+++ b/_includes/tutorials/merging/ksql/code/Makefile
@@ -15,3 +15,4 @@ tutorial:
 	bash -c 'diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-transient.log) <(sort $(DEV_OUTPUTS_DIR)/transient-query/output-0.log)'
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log | sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log | sort)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/merging/kstreams/code/Makefile
+++ b/_includes/tutorials/merging/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/merging/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	bash -c 'diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-events.json) <(sort $(DEV_OUTPUTS_DIR)/actual-output-events.json)'
+	reset

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/Makefile
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/naming-changelog-repartition-topics/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-total-output.txt $(DEV_OUTPUTS_DIR)/actual-output.txt
+	reset

--- a/_includes/tutorials/rekeying-function/ksql/code/Makefile
+++ b/_includes/tutorials/rekeying-function/ksql/code/Makefile
@@ -13,4 +13,4 @@ tutorial:
 	harness-runner ../../../../../_data/harnesses/rekeying-function/ksql.yml $(TEMP_DIR) $(SEQUENCE)
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-key-query.log) <(sort $(DEV_OUTPUTS_DIR)/key-query/output-0.log)"
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-query-rekeyed-stream.log) <(sort $(DEV_OUTPUTS_DIR)/query-rekeyed-stream/output-0.log)"
-	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-describe-function.log $(DEV_OUTPUTS_DIR)/describe-function/output-0.log"
+	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-describe-function.log $(DEV_OUTPUTS_DIR)/describe-function/output-0.log"	reset

--- a/_includes/tutorials/rekeying/ksql/code/Makefile
+++ b/_includes/tutorials/rekeying/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-key-query.log) <(sort $(DEV_OUTPUTS_DIR)/key-query/output-0.log)"
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-query-rekeyed-stream.log) <(sort $(DEV_OUTPUTS_DIR)/query-rekeyed-stream/output-0.log)"
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log|sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort)"
+	reset

--- a/_includes/tutorials/serialization/ksql/code/Makefile
+++ b/_includes/tutorials/serialization/ksql/code/Makefile
@@ -13,3 +13,4 @@ tutorial:
 	harness-runner ../../../../../_data/harnesses/serialization/ksql.yml $(TEMP_DIR) $(SEQUENCE)
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/serialization/kstreams/code/Makefile
+++ b/_includes/tutorials/serialization/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/serialization/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/proto-movies.txt $(DEV_OUTPUTS_DIR)/proto-movies-actual.txt
+	reset

--- a/_includes/tutorials/session-windows/ksql/code/Makefile
+++ b/_includes/tutorials/session-windows/ksql/code/Makefile
@@ -15,3 +15,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-transient-query.log) <(sort $(DEV_OUTPUTS_DIR)/transient-query/*.log)"
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-topic.log) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-topic/*.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/splitting/ksql/code/Makefile
+++ b/_includes/tutorials/splitting/ksql/code/Makefile
@@ -15,3 +15,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-outputs/negative-query.log $(DEV_OUTPUTS_DIR)/query-not-drama-fantasy/output-0.log
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-outputs/printed-topic.log) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/splitting/kstreams/code/Makefile
+++ b/_includes/tutorials/splitting/kstreams/code/Makefile
@@ -10,3 +10,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-drama-events.json $(DEV_OUTPUTS_DIR)/actual-drama-events.json
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-fantasy-events.json $(DEV_OUTPUTS_DIR)/actual-fantasy-events.json
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-other-events.json $(DEV_OUTPUTS_DIR)/actual-other-events.json
+	reset

--- a/_includes/tutorials/transforming/kafka/code/Makefile
+++ b/_includes/tutorials/transforming/kafka/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/transforming/kafka.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.json $(DEV_OUTPUTS_DIR)/actual-movies.json
+	reset

--- a/_includes/tutorials/transforming/ksql/code/Makefile
+++ b/_includes/tutorials/transforming/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/_includes/tutorials/transforming/kstreams/code/Makefile
+++ b/_includes/tutorials/transforming/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/transforming/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output-events.json $(DEV_OUTPUTS_DIR)/actual-movies.json
+	reset

--- a/_includes/tutorials/tumbling-windows/ksql/code/Makefile
+++ b/_includes/tutorials/tumbling-windows/ksql/code/Makefile
@@ -13,3 +13,4 @@ tutorial:
 	harness-runner ../../../../../_data/harnesses/tumbling-windows/ksql.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-window.log $(DEV_OUTPUTS_DIR)/transient-window/output-0.log
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient-query.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
+	reset

--- a/_includes/tutorials/tumbling-windows/kstreams/code/Makefile
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/tumbling-windows/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/windowed-counted-ratings.txt $(DEV_OUTPUTS_DIR)/windowed-ratings-actual.txt
+	reset

--- a/_includes/tutorials/udf/ksql/code/Makefile
+++ b/_includes/tutorials/udf/ksql/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	bash -c "diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-describe-function.log $(DEV_OUTPUTS_DIR)/describe-function/output-0.log"
 	bash -c "diff --strip-trailing-cr <(sort $(STEPS_DIR)/dev/expected-print-stream.log) <(sort $(DEV_OUTPUTS_DIR)/transient-query/output-0.log)"
 	bash -c "diff --strip-trailing-cr <(sort <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-topic.log)) <(sort <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log))"
+	reset

--- a/_includes/tutorials/window-final-result/kstreams/code/Makefile
+++ b/_includes/tutorials/window-final-result/kstreams/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/window-final-result/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	bash -c 'diff --strip-trailing-cr <(cat $(STEPS_DIR)/dev/expected-count.txt) <(cat $(DEV_OUTPUTS_DIR)/actual-count.txt)'
+	reset

--- a/templates/ksql/filtered/code/Makefile
+++ b/templates/ksql/filtered/code/Makefile
@@ -14,3 +14,4 @@ tutorial:
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-transient.log $(DEV_OUTPUTS_DIR)/transient-query/output-0.log
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print.log) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log)"
 	diff --strip-trailing-cr $(STEPS_DIR)/test/expected-results.log $(TEST_OUTPUTS_DIR)/test-results.log
+	reset

--- a/templates/kstreams/filtered/code/Makefile
+++ b/templates/kstreams/filtered/code/Makefile
@@ -8,3 +8,4 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/<TUTORIAL-SHORT-NAME>/kstreams.yml $(TEMP_DIR) $(SEQUENCE)
 	diff --strip-trailing-cr $(STEPS_DIR)/dev/expected-output.json $(DEV_OUTPUTS_DIR)/actual-output.json
+	reset


### PR DESCRIPTION
Mostly a hack, but by adding `reset` as the last command of `Makefile`, it helps with tests not-exiting even when successful.

This PR does not fix the issue, but since it improves the rate of false failures, I think it could be worth the trade-off of adding this as a stop-gap.

Relates to https://github.com/confluentinc/kafka-tutorials/issues/396 and https://github.com/confluentinc/kafka-tutorials/issues/156
