### PR TITLE
Document cache.max.bytes.buffering in finding-distinct events

### DIFF
--- a/_data/harnesses/finding-distinct/ksql.yml
+++ b/_data/harnesses/finding-distinct/ksql.yml
@@ -51,6 +51,10 @@ dev:
               render:
                 file: tutorials/finding-distinct/ksql/markup/dev/set-properties.adoc
 
+            - file: tutorial-steps/dev/set-properties2.sql
+              render:
+                file: tutorials/finding-distinct/ksql/markup/dev/set-properties2.adoc
+
             - file: tutorial-steps/dev/transient-window.sql
               render:
                 file: tutorials/finding-distinct/ksql/markup/dev/transient-window.adoc

--- a/_includes/tutorials/finding-distinct/ksql/code/tutorial-steps/dev/set-properties2.sql
+++ b/_includes/tutorials/finding-distinct/ksql/code/tutorial-steps/dev/set-properties2.sql
@@ -1,0 +1,1 @@
+SET 'cache.max.bytes.buffering' = '0';

--- a/_includes/tutorials/finding-distinct/ksql/markup/dev/set-properties2.adoc
+++ b/_includes/tutorials/finding-distinct/ksql/markup/dev/set-properties2.adoc
@@ -1,0 +1,5 @@
+Next, set `cache.max.bytes.buffering` to configure the frequency of output for tables. The value of `0` instructs ksqlDB to emit each matching record as soon as it is processed. Without this configuration, the queries below could appear to "miss" some records due to the default batching behavior.
+
++++++
+<pre class="snippet"><code class="sql">{% include_raw tutorials/finding-distinct/ksql/code/tutorial-steps/dev/set-properties2.sql %}</code></pre>
++++++

--- a/_includes/tutorials/finding-distinct/ksql/markup/dev/transient-window.adoc
+++ b/_includes/tutorials/finding-distinct/ksql/markup/dev/transient-window.adoc
@@ -1,4 +1,8 @@
-Let's experiment with these events. We need to create a query capable of displaying only distinct events, which means that duplicate IP addresses should be filtered out. Events are de-duped within a 2 minute window, and only unique clicks will be shown on that window. We are going to use the `LIMIT` keyword to limit the amount of records shown in the output. If you want to experiment with this query and assess if it is displaying the correct results, go ahead and remove the limit keyword.
+Let's experiment with these events. We need to create a query capable of displaying only distinct events, which means that duplicate IP addresses should be filtered out. Events are de-duped within a 2-minute window, and only unique clicks will be shown on that window.
+
+In the `docker-compose.yml` file above, note the configuration `KSQL_CACHE_MAX_BYTES_BUFFERING: 0` in the `ksql-server` entry. This setting affects the frequency of output for tables, and the value of `0` instructs ksqlDB to emit each matching record as soon as it is processed. Without this configuration, some records could appear to be "missed" due to the default batching behavior.
+
+We are going to use the `LIMIT` keyword to limit the amount of records shown in the output. If you want to experiment with this query and assess if it is displaying the correct results, go ahead and remove the limit keyword.
 
 +++++
 <pre class="snippet"><code class="sql">{% include_raw tutorials/finding-distinct/ksql/code/tutorial-steps/dev/transient-window.sql %}</code></pre>

--- a/_includes/tutorials/finding-distinct/ksql/markup/dev/transient-window.adoc
+++ b/_includes/tutorials/finding-distinct/ksql/markup/dev/transient-window.adoc
@@ -1,7 +1,5 @@
 Let's experiment with these events. We need to create a query capable of displaying only distinct events, which means that duplicate IP addresses should be filtered out. Events are de-duped within a 2-minute window, and only unique clicks will be shown on that window.
 
-In the `docker-compose.yml` file above, note the configuration `KSQL_CACHE_MAX_BYTES_BUFFERING: 0` in the `ksql-server` entry. This setting affects the frequency of output for tables, and the value of `0` instructs ksqlDB to emit each matching record as soon as it is processed. Without this configuration, some records could appear to be "missed" due to the default batching behavior.
-
 We are going to use the `LIMIT` keyword to limit the amount of records shown in the output. If you want to experiment with this query and assess if it is displaying the correct results, go ahead and remove the limit keyword.
 
 +++++

--- a/_includes/tutorials/finding-distinct/ksql/markup/prod/submit-to-api.adoc
+++ b/_includes/tutorials/finding-distinct/ksql/markup/prod/submit-to-api.adoc
@@ -4,4 +4,4 @@ Launch your statements into production by sending them to the REST API with the 
 <pre class="snippet"><code class="shell">{% include_raw tutorials/finding-distinct/ksql/code/tutorial-steps/prod/send-to-api.sh %}</code></pre>
 +++++
 
-As noted above, the `KSQL_CACHE_MAX_BYTES_BUFFERING: 0` configuration has been customized. Since this setting can affect overall throughput, it's a good idea to assess its impact on disk I/O in production environments. The Kafka Streams documentation details https://docs.confluent.io/current/streams/developer-guide/memory-mgmt.html#record-caches-in-the-dsl[the relevant internal mechanisms].
+In the steps above, we customized `cache.max.bytes.buffering` interactively via the CLI. Since this setting can affect overall throughput, it's a good idea to assess its impact on disk I/O in production environments. The Kafka Streams documentation details https://docs.confluent.io/current/streams/developer-guide/memory-mgmt.html#record-caches-in-the-dsl[the relevant internal mechanisms].

--- a/_includes/tutorials/finding-distinct/ksql/markup/prod/submit-to-api.adoc
+++ b/_includes/tutorials/finding-distinct/ksql/markup/prod/submit-to-api.adoc
@@ -3,3 +3,5 @@ Launch your statements into production by sending them to the REST API with the 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/finding-distinct/ksql/code/tutorial-steps/prod/send-to-api.sh %}</code></pre>
 +++++
+
+As noted above, the `KSQL_CACHE_MAX_BYTES_BUFFERING: 0` configuration has been customized. Since this setting can affect overall throughput, it's a good idea to assess its impact on disk I/O in production environments. The Kafka Streams documentation details https://docs.confluent.io/current/streams/developer-guide/memory-mgmt.html#record-caches-in-the-dsl[the relevant internal mechanisms].


### PR DESCRIPTION
addresses #487 

Called attention to the usage in step 3 of `Try it`, plus `Take it to production`.

[Preview link](http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/GH-487/6b17aa6e5956c6fc4d6bbb83c7a6a0aa9425309e/finding-distinct-events/ksql.html).
