### PR TITLE
MINOR: Restructure of semaphore yml for running build 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,9 +52,9 @@ blocks:
             - sem-version java $JAVA_VERSION
             - ./gradlew clean test
 
-  - name: Run the tests
+  - name: Run first block of tests
     execution_time_limit:
-      minutes: 15
+      minutes: 10
     task:
       secrets:
         - name: aws_credentials
@@ -167,6 +167,22 @@ blocks:
         - name: KSQL rekey stream with function tests
           commands:
             - make -C _includes/tutorials/rekeying-function/ksql/code tutorial
+  
+  - name: Run second block of tests
+    execution_time_limit:
+      minutes: 10
+    task:
+      secrets:
+        - name: aws_credentials
+      prologue:
+        commands:
+          - checkout
+          - >
+            aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
+          - sudo pip3 install -e harness_runner/
+          - >
+            find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}
+      jobs:
 
         - name: KStreams finding distinct events tests
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -54,7 +54,7 @@ blocks:
 
   - name: Run first block of tests
     execution_time_limit:
-      minutes: 10
+      minutes: 5
     task:
       secrets:
         - name: aws_credentials
@@ -170,7 +170,7 @@ blocks:
   
   - name: Run second block of tests
     execution_time_limit:
-      minutes: 10
+      minutes: 5
     task:
       secrets:
         - name: aws_credentials

--- a/settings.gradle
+++ b/settings.gradle
@@ -72,6 +72,8 @@ include '_includes:tutorials:udf:ksql:code'
 include '_includes:tutorials:window-final-result:kstreams:code'
 include '_includes:tutorials:produce-consume-lang:scala:code'
 include '_includes:tutorials:kafka-connect-datagen-ccloud:kafka:code'
+include '_includes:tutorials:generate-test-data-streams:kafka:code'
+include '_includes:tutorials:count-messages:kafka:code'
 // <end>
 
 // if new tutorial wasn't included in `settings.gradle` build will fail


### PR DESCRIPTION
Testing the restructuring of the semaphore yml file to get builds running under the 50 parallel limit