### PR TITLE
ISSUE_524: Fix spelling and punctuation in some areas in 'Console Producer and Consumer Basics' page

### DIFF
--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -286,7 +286,7 @@ console-consumer-produer-basic:
   meta-description: "Produce and consume your first message with Kafka"
   slug: "/kafka-console-consumer-producer-basics"
   question: "What is the simplest way to write messages to and read messages from Kafka?"
-  introduction: "So you are excited to get started with Kafka and youd like to produce and consume some basic messages and you want to do so quickly.  In this tutorial we'll show you how to produce and consume messages from the command line with no code! Note this tutorial doesn't cover using (de)serializers. Using (de)serializers with the console consumer and producer are covered in separate tutorials"
+  introduction: "So you are excited to get started with Kafka and you'd like to produce and consume some basic messages and you want to do so quickly.  In this tutorial we'll show you how to produce and consume messages from the command line with no code! Note this tutorial doesn't cover using (de)serializers. Using (de)serializers with the console consumer and producer are covered in separate tutorials."
   status:
     ksql: disabled
     kstreams: disabled

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/markup/dev/consume-topic-from-beginning.adoc
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/markup/dev/consume-topic-from-beginning.adoc
@@ -1,4 +1,4 @@
-Next let's open up a console consumer again, but this time you'll ready everything that your producer has sent to the topic. you created in the previous step.
+Next, let's open up a console consumer again. This time you'll read everything your producer has sent to the topic you created in the previous step.
 
 Run this command in the container shell you created for your first consumer and note the additional property `--from-beginning`:
 

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/markup/dev/consume-topic-from-beginning.adoc
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/markup/dev/consume-topic-from-beginning.adoc
@@ -1,4 +1,4 @@
-Next let's open up a console consumer again, but this time you'll ready everthing that your producer has sent to the topic. you created in the previous step.
+Next let's open up a console consumer again, but this time you'll ready everything that your producer has sent to the topic. you created in the previous step.
 
 Run this command in the container shell you created for your first consumer and note the additional property `--from-beginning`:
 
@@ -15,4 +15,4 @@ After the consumer starts you should see the following output in a few seconds:
 
 One word of caution with using the `--from-beginning` flag. As the name implies this setting forces the consumer retrieve _**every record**_ currently on the topic.  So it's best to use when testing  and learning and not on a production topic.
 
-Again, once you've recieved all records, close this console consumer by entering a `CTRL+C`.
+Again, once you've received all records, close this console consumer by entering a `CTRL+C`.

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/markup/dev/produce-topic-from-beginning.adoc
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/markup/dev/produce-topic-from-beginning.adoc
@@ -1,4 +1,4 @@
-In the first consumer example, you observed all incoming records becuase the consumer was already running, waiting for incoming records.
+In the first consumer example, you observed all incoming records because the consumer was already running, waiting for incoming records.
 
 But what if the records were produced before you started your consumer?  In that case you wouldn't see the records as the console consumer by default only reads incoming records arriving after it has started up.
 

--- a/_includes/tutorials/console-consumer-produer-basic/kafka/markup/dev/produce-topic.adoc
+++ b/_includes/tutorials/console-consumer-produer-basic/kafka/markup/dev/produce-topic.adoc
@@ -10,13 +10,13 @@ From inside the second terminal on the broker container, run the following comma
 <pre class="snippet"><code class="shell">{% include_raw tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/console-producer.sh %}</code></pre>
 +++++
 
-The producer will start and wait for you to enter input.  Each line represents one record and to send it you'll hit the enter key.  If you type multiple words then hit enter, the entire line is considered one record.
+The producer will start and wait for you to enter input.  Each line represents one record and to send it you'll hit the enter key.  If you type multiple words and then hit enter, the entire line is considered one record.
 
-Try typing one line at a time, hit enter and go back to the console consumer window and look for the output. Or you can select all the records and send at one time.
+Try typing one line at a time, hit enter and go back to the console consumer window and look for the output. Or, you can select all the records and send at one time.
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/console-consumer-produer-basic/kafka/code/tutorial-steps/dev/input-step-one.txt %}</code></pre>
 +++++
 
 
-Once you've sent all the records you should see the same output in your console consumer window. After you've confirmed recieving all records go ahead and close the consumer by entering `CTRL+C`.
+Once you've sent all the records you should see the same output in your console consumer window. After you've confirmed receiving all records, go ahead and close the consumer by entering `CTRL+C`.


### PR DESCRIPTION
- Fixed spelling and punctuation in some areas in **Console Producer and Consumer Basics, no (de)serializers** page. 

- https://github.com/confluentinc/kafka-tutorials/issues/524
