### PR TITLE
MINOR: Increase timeouts for sempaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -54,7 +54,7 @@ blocks:
 
   - name: Run first block of tests
     execution_time_limit:
-      minutes: 5
+      minutes: 10
     task:
       secrets:
         - name: aws_credentials
@@ -170,7 +170,7 @@ blocks:
   
   - name: Run second block of tests
     execution_time_limit:
-      minutes: 5
+      minutes: 10
     task:
       secrets:
         - name: aws_credentials


### PR DESCRIPTION
Originally I reduced the timeout for semaphore blocks to 5 minutes, but that is too strict as some tests run close to 5 minutes now.  Increasing the timeout to 10 minutes. For example the #565 PR all tests passed, but the build failed because one test ran over 5 minutes.