### PR TITLE
Proposed new layout for the front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,19 +33,55 @@
         <div class="card">
           <div class="title">
             <img src="{{ "/assets/img/icon-kafka-blue.svg" | relative_url }}" />
-            <div>Kafka 101</div>
+            <div>Producing and Consuming messages</div>
           </div>
           <ul>
-            <li><a href="kafka-console-consumer-producer-basics/kafka.html">Console producer and consumer basics</a></li>
-            <li><a href="ccloud-produce-consume/kafka.html">Console producer and consumer basics with Confluent Cloud</a></li>
-            <li><a href="kafka-console-consumer-primitive-keys-values/kafka.html">Console consumer with primitive keys and values</a></li>
-            <li><a href="kafka-console-consumer-read-specific-offsets-partitions/kafka.html">Console consumer reads from a specific offset and partition</a></li>
-            <li><a href="produce-consume-lang/scala.html">Produce and consume messages with clients in multiple languages</a></li>
-            <li><a href="change-topic-partitions-replicas/ksql.html">Change the number of partitions and replicas of a Kafka topic</a></li>
-            <li><a href="creating-first-apache-kafka-producer-application/kafka.html">Build your first Kafka producer application</a></li>
-            <li><a href="kafka-producer-callback-application/kafka.html">Using Callbacks to handle Kafka producer responses</a></li>
-            <li><a href="creating-first-apache-kafka-consumer-application/kafka.html">Build your first Kafka consumer application</a></li>
+            <li><a href="kafka-console-consumer-producer-basics/kafka.html">The basics</a></li>
+            <li><a href="ccloud-produce-consume/kafka.html">Using Confluent Cloud</a></li>
+            <li><a href="kafka-console-consumer-primitive-keys-values/kafka.html">Primitive keys and values</a></li>
+            <li><a href="kafka-console-consumer-read-specific-offsets-partitions/kafka.html">Read from a specific offset and partition</a></li>
+            <li><a href="kafka-producer-callback-application/kafka.html">Using Callbacks</a></li>
+          </ul>
+        </div>
+        
+        
+        <div class="card">
+          <div class="title">
+            <img src="{{ "/assets/img/icon-kafka-blue.svg" | relative_url }}" />
+            <div>Building Applications</div>
+          </div>
+          <ul>
+            <li><a href="produce-consume-lang/scala.html">Clients in multiple languages</a></li>
+            <li><a href="creating-first-apache-kafka-producer-application/kafka.html">Your first Kafka producer application</a></li>
+            <li><a href="creating-first-apache-kafka-consumer-application/kafka.html">Your first Kafka consumer application</a></li>
+          </ul>
+        </div>
+        
+        <div class="card">
+          <div class="title">
+            <img src="{{ "/assets/img/icon-kafka-blue.svg" | relative_url }}" />
+            <div>Kafka topics</div>
+          </div>
+          <ul>
+            <li><a href="change-topic-partitions-replicas/ksql.html">Change the number of partitions and replicas</a></li>
             <li><a href="how-to-count-messages-on-a-kafka-topic/ksql.html">Count the number of messages in a Kafka topic</a></li>
+          </ul>
+        </div>
+
+      </div>
+
+      <div class="cards secondary-card-row">
+
+        <div class="card">
+          <div class="title">
+            <img src="{{ "/assets/img/icon-time.svg" | relative_url }}" />
+            <div>Collect data over time.</div>
+          </div>
+          <ul>
+            <li><a href="create-tumbling-windows/ksql.html">Create tumbling windows</a></li>
+            <li><a href="create-hopping-windows/ksql.html">Create hopping windows</a></li>
+            <li><a href="create-session-windows/ksql.html">Create session windows</a></li>
+            <li><a href="window-final-result/kstreams.html">Emit a final result from a time window</a></li>
           </ul>
         </div>
 
@@ -102,18 +138,6 @@
           </ul>
         </div>
 
-        <div class="card">
-          <div class="title">
-            <img src="{{ "/assets/img/icon-time.svg" | relative_url }}" />
-            <div>Collect data over time.</div>
-          </div>
-          <ul>
-            <li><a href="create-tumbling-windows/ksql.html">Create tumbling windows</a></li>
-            <li><a href="create-hopping-windows/ksql.html">Create hopping windows</a></li>
-            <li><a href="create-session-windows/ksql.html">Create session windows</a></li>
-            <li><a href="window-final-result/kstreams.html">Emit a final result from a time window</a></li>
-          </ul>
-        </div>
 
         <div class="card">
           <div class="title">


### PR DESCRIPTION
Some of the nav is IMHO starting to look a bit messy - we have these category cards and then a lot of words in each one. 

* For example, if you look at the number of occurrences of `console` and `producer` and `consumer` in the `Kafka 101` box, there's a lot of redundancy and thus extra work for people parsing it when figuring out what to click on. 

![image](https://user-images.githubusercontent.com/3671582/95312183-83836b80-0886-11eb-91db-10682d8d8b46.png)

* We should be careful not to bracket _everything_ under 101, since otherwise it just becomes `Kafka` :) What is truly 101? 

I think though that this could improve the nav experience and thus the stickiness of the pages. People hitting this from Google might be fine if they land on a particular tutorial but if we're pushing people to the KT home page to learn stuff we should make it as low-friction as possible to explore

This PR is my proposed amendment to the nav: 

![image](https://user-images.githubusercontent.com/3671582/95311880-22f42e80-0886-11eb-82e5-26b3a9d16766.png)
