### PR TITLE
MINOR: Revert cp-kafka-connect-base to 5.5.1

### DIFF
--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/Dockerfile
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:6.0.0
+FROM confluentinc/cp-kafka-connect-base:5.5.1
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 


### PR DESCRIPTION
Needed to set `cp-kafka-connect-base` back to `5.5.1` otherwise the tutorial fails due to source topic not getting created.

Covers https://github.com/confluentinc/kafka-tutorials/issues/584