### PR TITLE
add docker hub login

### DIFF
--- a/.semaphore/live-site-deploy.yml
+++ b/.semaphore/live-site-deploy.yml
@@ -16,6 +16,6 @@ blocks:
             - cache restore
             - npm install
             - gem install bundler --no-ri --no-rdoc
-            - bundle install            
+            - bundle install
             - JEKYLL_ENV=production bundle exec jekyll build
             - aws s3 cp --recursive ./_site s3://kafka-tutorials.confluent.io/

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,7 +69,7 @@ blocks:
           - checkout
           - >
             aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
-          - docker login
+          - docker login --username $(DOCKERHUB_USER) --password $(DOCKERHUB_APIKEY)
           - sudo pip3 install -e harness_runner/
           - >
             find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}
@@ -187,7 +187,7 @@ blocks:
           - checkout
           - >
             aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
-          - docker login
+          - docker login --username $(DOCKERHUB_USER) --password $(DOCKERHUB_APIKEY)
           - sudo pip3 install -e harness_runner/
           - >
             find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,11 +63,13 @@ blocks:
     task:
       secrets:
         - name: aws_credentials
+        - name: dockerhub-semaphore-cred
       prologue:
         commands:
           - checkout
           - >
             aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
+          - docker login
           - sudo pip3 install -e harness_runner/
           - >
             find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}
@@ -179,11 +181,13 @@ blocks:
     task:
       secrets:
         - name: aws_credentials
+        - name: dockerhub-semaphore-cred
       prologue:
         commands:
           - checkout
           - >
             aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
+          - docker login
           - sudo pip3 install -e harness_runner/
           - >
             find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -69,7 +69,7 @@ blocks:
           - checkout
           - >
             aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
-          - docker login --username $(DOCKERHUB_USER) --password $(DOCKERHUB_APIKEY)
+          - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
           - sudo pip3 install -e harness_runner/
           - >
             find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}
@@ -187,7 +187,7 @@ blocks:
           - checkout
           - >
             aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
-          - docker login --username $(DOCKERHUB_USER) --password $(DOCKERHUB_APIKEY)
+          - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
           - sudo pip3 install -e harness_runner/
           - >
             find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}


### PR DESCRIPTION
# what
---------------
Docker hub will have a layer limit about 50/hr pull operation for anonymous users. Add dockerhub cred and dockerhub login to make sure it pull image with confluentsemaphore service account. It should make it have 200/hr pull limit, we could also upgrade the service account to "pro" to have unlimited pulls.

# how
-------------
Add dockerhub cred and docker login.