### PR TITLE
GH-602 address #602: consistency in calling create_ccloud_stack

### DIFF
--- a/_includes/tutorials/ccloud-produce-consume/kafka/code/tutorial-steps/dev/run-ccloud-stack.sh
+++ b/_includes/tutorials/ccloud-produce-consume/kafka/code/tutorial-steps/dev/run-ccloud-stack.sh
@@ -1,3 +1,3 @@
 CLUSTER_CLOUD=aws
 CLUSTER_REGION=us-west-2 
-ccloud::create_ccloud_stack false
+ccloud::create_ccloud_stack

--- a/_includes/tutorials/ccloud-produce-consume/kafka/markup/dev/setup-ccloud.adoc
+++ b/_includes/tutorials/ccloud-produce-consume/kafka/markup/dev/setup-ccloud.adoc
@@ -18,9 +18,7 @@ NOTE: To avoid unexpected charges, carefully evaluate the cost of resources befo
 <pre class="snippet"><code class="shell">{% include_raw tutorials/ccloud-produce-consume/kafka/code/tutorial-steps/dev/run-ccloud-stack.sh %}</code></pre>
 +++++
 
-The `false` passed to the command indicates we do not want to create a ksqlDB application which we do not need for this tutorial.
-
-After running the `ccloud::create_ccloud_stack` function, you should output similar to the following:
+After running the `ccloud::create_ccloud_stack` function, you should see output similar to the following:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/ccloud-produce-consume/kafka/code/tutorial-steps/dev/expected-ccloud-create.log %}</code></pre>


### PR DESCRIPTION
Consistency in calling create_ccloud_stack.

And default is now ksqlDB=false (see https://github.com/confluentinc/examples/pull/843)