### PR TITLE
fix the produce/consume-scala tutorial by setting up a jar base name

### DIFF
--- a/_includes/tutorials/produce-consume-lang/scala/code/build.gradle
+++ b/_includes/tutorials/produce-consume-lang/scala/code/build.gradle
@@ -78,11 +78,13 @@ configure(subprojects) {
 }
 
 configure(project('produce-consume-scala-producer-app')) {
+    shadowJar.archiveBaseName = "app-producer"
     mainClassName = 'io.confluent.developer.produce.Producer'
     jib.to.image = "io.confluent.developer/scala-producer:${version}"
 }
 
 configure(project('produce-consume-scala-consumer-app')) {
+    shadowJar.archiveBaseName = "app-consumer"
     mainClassName = 'io.confluent.developer.consume.Consumer'
     jib.to.image = "io.confluent.developer/scala-consumer:${version}"
 }


### PR DESCRIPTION
Here is a modification missing from #532, the migration from sbt to gradle 