### PR TITLE
cherrypick fix for flaky ksql rekey test to ksqldb-latest

### DIFF
--- a/_includes/tutorials/rekeying/ksql/code/Makefile
+++ b/_includes/tutorials/rekeying/ksql/code/Makefile
@@ -12,4 +12,6 @@ tutorial:
 	harness-runner ../../../../../_data/harnesses/rekeying/ksql.yml $(TEMP_DIR)
 	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
 	diff --strip-trailing-cr --ignore-space-change $(STEPS_DIR)/dev/expected-describe.log $(DEV_OUTPUTS_DIR)/describe-output/output-0.log
-	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-output.log|sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort)"
+	# Unless ksqlDB adds support for SLEEP, or we split the docker_ksql_cli_session and insert a bash sleep step (a lot of heavy lifting), this option will hopefully suffice for now. It simply greps out the offending KAFKA_STRING mention in the test at the end.
+	# See https://github.com/confluentinc/kafka-tutorials/issues/510
+	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-output.log|sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort|grep -v KAFKA_STRING)"


### PR DESCRIPTION
### Description

Cherry-pick https://github.com/confluentinc/kafka-tutorials/pull/555 to ksqldb-latest branch, to avoid flaky failures during manual release testing. 

Slack: https://confluent.slack.com/archives/CTSV6CALC/p1604948386008600

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
