### PR TITLE
MINOR: update gem install command

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,7 +33,7 @@ blocks:
           - checkout
           - cache restore
           - npm install
-          - gem install bundler -​-no-document
+          - gem install bundler
           - bundle install
           - cache store
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,7 +33,7 @@ blocks:
           - checkout
           - cache restore
           - npm install
-          - gem install bundler --no-ri --no-rdoc
+          - gem install bundler -​-no-document
           - bundle install
           - cache store
       jobs:


### PR DESCRIPTION
### Description
The build was failing to compile the jekyll site due to `invalid option: --no-ri --no-doc` failure
<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
