### PR TITLE
DEVX-2288: KT Anomaly Detection test is flaky

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -179,6 +179,10 @@ blocks:
           commands:
             - make -C _includes/tutorials/produce-consume-lang/scala/code tutorial
 
+        - name: KSQL anomaly detection tests
+          commands:
+            - make -C _includes/tutorials/anomaly-detection/ksql/code tutorial
+
   - name: Run second block of tests
     execution_time_limit:
       minutes: 10
@@ -324,10 +328,6 @@ blocks:
         - name: KSQL masking data tests
           commands:
             - make -C _includes/tutorials/masking-data/ksql/code tutorial
-
-        - name: KSQL anomaly detection tests
-          commands:
-            - make -C _includes/tutorials/anomaly-detection/ksql/code tutorial
 
         - name: Kafka Consuming and Producing AVRO messages with console tools tests
           commands:

--- a/_data/harnesses/anomaly-detection/ksql.yml
+++ b/_data/harnesses/anomaly-detection/ksql.yml
@@ -66,7 +66,19 @@ dev:
             - file: tutorial-steps/dev/populate-suspicious-names.sql
               render:
                 file: tutorials/anomaly-detection/ksql/markup/dev/populate-suspicious-names.adoc
-
+        - action: sleep
+          ms: 3000
+          render:
+            skip: true
+        - action: docker_ksql_cli_session
+          container: ksqldb-cli
+          docker_bootup_file: tutorial-steps/dev/start-cli.sh
+          stdout:
+            directory: tutorial-steps/dev/outputs
+          column_width: 25
+          render:
+            skip: true
+          stdin:
             - file: tutorial-steps/dev/populate-transactions.sql
               render:
                 file: tutorials/anomaly-detection/ksql/markup/dev/populate-transactions.adoc

--- a/_data/harnesses/anomaly-detection/ksql.yml
+++ b/_data/harnesses/anomaly-detection/ksql.yml
@@ -67,7 +67,7 @@ dev:
               render:
                 file: tutorials/anomaly-detection/ksql/markup/dev/populate-suspicious-names.adoc
         - action: sleep
-          ms: 3000
+          ms: 5000
           render:
             skip: true
         - action: docker_ksql_cli_session


### PR DESCRIPTION
### Description
Add sleep between populating table and stream. There seem to be some other tests failing in block 1, so I moved this test up to block 1 to ensure it got executed with every semaphore run. Over 6 valid runs (valid run=block is run where this test was present) in semaphore, this test passed every time. Locally this is running without problems for me. 

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/devx-2288
