### PR TITLE
MINOR: Add back create schema dir step, breaks semaphore test run

### DIFF
--- a/_data/harnesses/console-consumer-producer-avro/kafka.yml
+++ b/_data/harnesses/console-consumer-producer-avro/kafka.yml
@@ -33,6 +33,12 @@ dev:
 
     - title: Create a schema
       content:
+        - change_directory: console-consumer-producer-avro
+          action: execute
+          file: tutorial-steps/dev/make-schema-dir.sh
+          render:
+            file: tutorials/console-consumer-producer-avro/kafka/markup/dev/make-schema-dir.adoc
+
         - action: make_file
           file: schema/order_detail.avsc
           render:

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/make-schema-dir.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/make-schema-dir.sh
@@ -1,0 +1,1 @@
+mkdir schema

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/markup/dev/make-schema-dir.adoc
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/markup/dev/make-schema-dir.adoc
@@ -1,0 +1,5 @@
+Before you create a schema, let's make a directory to put it in:
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/make-schema-dir.sh %}</code></pre>
++++++


### PR DESCRIPTION
### Description

This [PR](https://github.com/confluentinc/kafka-tutorials/pull/675) removed the `make schema directory` step, but it's required for running the test-harness on semaphore

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
