### PR TITLE
MINOR: update for test container changes

### DIFF
--- a/_includes/tutorials/produce-consume-lang/scala/code/build.gradle
+++ b/_includes/tutorials/produce-consume-lang/scala/code/build.gradle
@@ -36,7 +36,7 @@ allprojects {
         implementation "io.confluent:kafka-streams-avro-serde:5.5.0"
         implementation "com.sksamuel.avro4s:avro4s-core_2.13:4.0.4"
         testImplementation "org.scalatest:scalatest_2.13:3.3.0-SNAP3"
-        testImplementation "org.testcontainers:kafka:1.14.3"
+        testImplementation "org.testcontainers:kafka:1.15.1"
 
         // presentation boiler plate
         implementation "com.lihaoyi:cask_2.13:0.7.8"

--- a/_includes/tutorials/produce-consume-lang/scala/code/src/test/scala/io/confluent/developer/KafkaFlatSpec.scala
+++ b/_includes/tutorials/produce-consume-lang/scala/code/src/test/scala/io/confluent/developer/KafkaFlatSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, GivenWhenThen, Inspectors}
 import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.utility.DockerImageName
 
 import scala.jdk.CollectionConverters._
 
@@ -21,7 +22,7 @@ trait KafkaFlatSpec extends AnyFlatSpec
   val testTopics: Vector[TopicSpec]
 
   @Rule
-  val kafka = new KafkaContainer
+  val kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.0.0"))
   lazy val admin: Admin = Admin.create(Map[String, AnyRef]("bootstrap.servers" -> kafka.getBootstrapServers).asJava)
 
   override def beforeAll(): Unit = {

--- a/_includes/tutorials/transforming/kafka/code/build.gradle
+++ b/_includes/tutorials/transforming/kafka/code/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   implementation 'org.slf4j:slf4j-simple:1.7.30'
   implementation 'io.confluent:kafka-streams-avro-serde:5.5.1'
   testImplementation 'junit:junit:4.13.1'
-  testImplementation "org.testcontainers:kafka:1.14.3"
+  testImplementation "org.testcontainers:kafka:1.15.1"
 }
 
 test {

--- a/_includes/tutorials/transforming/kafka/code/configuration/test.properties
+++ b/_includes/tutorials/transforming/kafka/code/configuration/test.properties
@@ -1,6 +1,6 @@
-confluent.version=5.3.0
+confluent.version=6.0.0
 bootstrap.servers=localhost:29092
-schema.registry.url=http://localhost:8081
+schema.registry.url=mock://localhost:8081
 
 input.topic.name=raw-movies
 input.topic.partitions=1

--- a/_includes/tutorials/transforming/kafka/code/src/test/java/io/confluent/developer/TransformEventsTest.java
+++ b/_includes/tutorials/transforming/kafka/code/src/test/java/io/confluent/developer/TransformEventsTest.java
@@ -1,7 +1,6 @@
 package io.confluent.developer;
 
 import io.confluent.developer.avro.Movie;
-
 import io.confluent.developer.avro.RawMovie;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -11,17 +10,15 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.ExternalResource;
+import org.junit.Test;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
@@ -34,14 +31,9 @@ public class TransformEventsTest {
 
     @ClassRule
     public static KafkaContainer kafkaContainer = new KafkaContainer(
-        ENVIRONMENT_PROPERTIES.getProperty("confluent.version"));
-
-    @Rule
-    public SchemaRegistryContainer schemaRegistryContainer =
-        new SchemaRegistryContainer(ENVIRONMENT_PROPERTIES
-            .getProperty("confluent.version"))
-            .withKafka(kafkaContainer);
-
+            DockerImageName.parse("confluentinc/cp-kafka:" +
+                    ENVIRONMENT_PROPERTIES.getProperty("confluent.version")));
+    
     private String inputTopic, outputTopic;
     private TransformationEngine transEngine;
     private KafkaProducer<String, Movie> movieProducer;
@@ -54,7 +46,6 @@ public class TransformEventsTest {
 
         TransformEvents transformEvents = new TransformEvents();
         ENVIRONMENT_PROPERTIES.put("bootstrap.servers", kafkaContainer.getBootstrapServers());
-        ENVIRONMENT_PROPERTIES.put("schema.registry.url", schemaRegistryContainer.getTarget());
         transformEvents.createTopics(ENVIRONMENT_PROPERTIES);
 
         inputTopic = ENVIRONMENT_PROPERTIES.getProperty("input.topic.name");


### PR DESCRIPTION
### Description
The `gradle` build started failing with 
```
Cause: com.github.dockerjava.api.exception.NotFoundException: {"message":"No such image: testcontainersofficial/ryuk:0.3.0"}
```
The solution is to update the `testcontainers:kafka` version to `1.15.1`.  
### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
