### PR TITLE
fix sed invocation to deal with slash in registry

### DIFF
--- a/tools/update-ksqldb-version.sh
+++ b/tools/update-ksqldb-version.sh
@@ -16,7 +16,7 @@ registry=${2:-}
 repo_prefix=
 
 if [[ -n "$registry" ]]; then
-    repo_prefix="$registry\/confluentinc\/"
+    repo_prefix="${registry}confluentinc\/"
 else
     repo_prefix="confluentinc\/"
 fi
@@ -26,8 +26,8 @@ cd "$(dirname $0)/.."
 # both the xargs and sed incanations may need to be changed for non-macOS contexts
 if [ "$(uname)" == "Darwin" ]; then
   find _includes/tutorials/**/ksql -name docker-compose.yml \
-      | xargs -I {} sed -i '' -E "s/image:.*confluentinc\/(ksqldb.+):.+/image: $repo_prefix\1:$version/g" {}
+      | xargs -I {} sed -i '' -E "s@image:.*confluentinc\/(ksqldb.+):.+@image: $repo_prefix\1:$version@g" {}
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   find _includes/tutorials/**/ksql -name docker-compose.yml \
-      | xargs -I {} sed -i -E "s/image:.*confluentinc\/(ksqldb.+):.+/image: $repo_prefix\1:$version/g" {}
+      | xargs -I {} sed -i -E "s@image:.*confluentinc\/(ksqldb.+):.+@image: $repo_prefix\1:$version@g" {}
 fi


### PR DESCRIPTION
### Description

fixes the sed invocation to use another delimiter (@) since the docker registry probably
has unescaped slashes. Also, expect the registry to end with a '/'