### PR TITLE
chore: divide Semaphore jobs into two execution blocks

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,7 +21,7 @@ global_job_config:
 blocks:
 - execution_time_limit:
     minutes: 20
-  name: Run the tests
+  name: Run the tests part 1
   task:
     jobs:
     - commands:
@@ -57,6 +57,12 @@ blocks:
     - commands:
       - make -C _includes/tutorials/aggregating-minmax/ksql/code tutorial
       name: KSQL aggregation MIN/MAX tests
+
+- execution_time_limit:
+    minutes: 20
+  name: Run the tests part 2
+  task:
+    jobs:
     - commands:
       - make -C _includes/tutorials/aggregating-sum/ksql/code tutorial
       name: KSQL aggregation sum tests

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,7 +20,7 @@ global_job_config:
         find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}
 blocks:
 - execution_time_limit:
-    minutes: 20
+    minutes: 10
   name: Run the tests part 1
   task:
     jobs:
@@ -59,7 +59,7 @@ blocks:
       name: KSQL aggregation MIN/MAX tests
 
 - execution_time_limit:
-    minutes: 20
+    minutes: 10
   name: Run the tests part 2
   task:
     jobs:


### PR DESCRIPTION
This will roughly double time in CI, hopefully with the benefit of reduced flakiness.
