### PR TITLE
MINOR: Fix link in slug entry to match the link tutorials/produce-consume-lang/scala.html

### DIFF
--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -362,7 +362,7 @@ kafka-consumer-application:
 produce-consume-lang:
   title: "Produce and Consume Records in multiple languages"
   meta-description: "Produce and Consume events from Apache Kafka in multiple languages"
-  slug: "/produce-and-consume-lang/"
+  slug: "/produce-consume-lang"
   question: "How can I produce and consume events from Kafka using a programming language other than Java?"
   introduction: "You want to enrich and expose a list of books from a library. You have to produce an event for each book acquisition (title, editor, release ...), and consume back the same events to serve the book collection over HTTP."
   status:


### PR DESCRIPTION
### Description

The link `produce-and-consume-lang` is incorrect it should be `produce-consume-lang/`

Fixes https://github.com/confluentinc/kafka-tutorials/issues/715

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

 http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/MINOR_fix_scala_produce_consume_button_link/ 
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
