### PR TITLE
[MINOR] Maintain consistency in KT titles on the cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,11 +177,10 @@
             <div>Access Fields</div>
           </div>
           <ul>
-            <li><a href="working-with-nested-json/ksql.html">Nested JSON</a></li>
             <li><a href="working-with-json-different-structure/ksql.html">Heterogenous JSON</a></li>
-            <li><a href="transform-a-stream-of-events/ksql.html">Transform a stream of events</a></li>
+            <li><a href="working-with-nested-json/ksql.html">Nested JSON</a></li>
             <li><a href="flatten-nested-data/ksql.html">Flatten deeply nested events</a></li>
-            <li><a href="geo-distance/ksql.html">Calculate lat-long distance</a></li>
+            <li><a href="transform-a-stream-of-events/ksql.html">Transform a stream of events</a></li>
           </ul>
         </div>
 
@@ -195,6 +194,7 @@
             <li><a href="concatenation/ksql.html">Concatenation</a></li>
             <li><a href="masking-data/ksql.html">Mask data</a></li>
             <li><a href="column-difference/ksql.html">Calculate column difference</a></li>
+            <li><a href="geo-distance/ksql.html">Calculate lat-long distance</a></li>
           </ul>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -40,10 +40,10 @@
            <ul>
             <li><a href="kafka-console-consumer-producer-basics/kafka.html">The basics</a></li>
             <li><a href="kafka-console-consumer-primitive-keys-values/kafka.html">Primitive keys and values</a></li>
-            <li><a href="message-ordering/kafka.html">Maintaining message ordering</a></li>
-            <li><a href="kafka-console-consumer-read-specific-offsets-partitions/kafka.html">Reading from an offset and partition</a></li>
-            <li><a href="kafka-producer-callback-application/kafka.html">Using Callbacks</a></li>
-            <li><a href="ccloud-produce-consume/kafka.html">Using Confluent Cloud CLI</a></li>
+            <li><a href="message-ordering/kafka.html">Maintain message ordering</a></li>
+            <li><a href="kafka-console-consumer-read-specific-offsets-partitions/kafka.html">Read from an offset and partition</a></li>
+            <li><a href="kafka-producer-callback-application/kafka.html">Callbacks</a></li>
+            <li><a href="ccloud-produce-consume/kafka.html">Confluent Cloud CLI</a></li>
           </ul>
         </div>
 
@@ -53,9 +53,9 @@
             <div>Build Applications</div>
           </div>
           <ul>
-            <li><a href="produce-consume-lang/scala.html">Clients in multiple languages</a></li>
             <li><a href="creating-first-apache-kafka-producer-application/kafka.html">Your first Kafka producer application</a></li>
             <li><a href="creating-first-apache-kafka-consumer-application/kafka.html">Your first Kafka consumer application</a></li>
+            <li><a href="produce-consume-lang/scala.html">Clients in multiple languages</a></li>
           </ul>
         </div>
 
@@ -65,7 +65,7 @@
             <div>Kafka topics</div>
           </div>
           <ul>
-            <li><a href="change-topic-partitions-replicas/ksql.html">Updating partitions and replicas</a></li>
+            <li><a href="change-topic-partitions-replicas/ksql.html">Update partitions and replicas</a></li>
             <li><a href="how-to-count-messages-on-a-kafka-topic/ksql.html">Count the number of messages</a></li>
           </ul>
         </div> 
@@ -81,7 +81,7 @@
           </div>
           <ul>
             <li><a href="split-a-stream-of-events-into-substreams/ksql.html">Split a stream into substreams</a></li>
-            <li><a href="merge-many-streams-into-one-stream/ksql.html">Merge many streams into one stream</a></li>
+            <li><a href="merge-many-streams-into-one-stream/ksql.html">Merge many streams into one</a></li>
             <li><a href="dynamic-output-topic/kstreams.html">Choose the output topic dynamically</a></li>
             <li><a href="filter-a-stream-of-events/ksql.html">Filter a stream of events</a></li>
             <li><a href="finding-distinct-events/ksql.html">Find distinct events</a></li>
@@ -100,7 +100,7 @@
             <li><a href="naming-stateful-operations/kstreams.html">Name stateful operations</a></li>
             <li><a href="kafka-streams-convert-to-ktable/kstreams.html">Convert a KStream to a KTable</a></li>  
             <li><a href="handling-deserialization-errors/ksql.html">Handle deserialization errors</a></li>
-            <li><a href="changing-serialization-format/ksql.html">Converting serialization format</a></li>
+            <li><a href="changing-serialization-format/ksql.html">Convert serialization format</a></li>
             <li><a href="kafka-streams-schedule-operations/kstreams.html">Scheduling operations</a></li>
           </ul>
         </div>
@@ -113,7 +113,7 @@
           <ul>
             <li><a href="create-stateful-aggregation-count/ksql.html">Count a stream of events</a></li>
             <li><a href="create-stateful-aggregation-sum/ksql.html">Sum a stream of events</a></li>
-            <li><a href="create-stateful-aggregation-minmax/ksql.html">Finding the min/max</a></li>
+            <li><a href="create-stateful-aggregation-minmax/ksql.html">Find the min/max</a></li>
             <li><a href="aggregating-average/kstreams.html">Calculate a running average</a></li>
             <li><a href="cogrouping-streams/kstreams.html">Cogrouping aggregates</a></li>
           </ul>
@@ -148,7 +148,7 @@
             <li><a href="create-hopping-windows/ksql.html">Hopping windows</a></li>
             <li><a href="create-session-windows/ksql.html">Session windows</a></li>
             <li><a href="sliding-windows/kstreams.html">Sliding windows</a></li>
-            <li><a href="window-final-result/kstreams.html">Emiting a final result</a></li>
+            <li><a href="window-final-result/kstreams.html">Emit a final result</a></li>
             <li><a href="anomaly-detection/ksql.html">Anomaly detection</a></li>
             <li><a href="time-concepts/ksql.html">Event-time semantics</a></li>
           </ul>
@@ -161,9 +161,9 @@
           </div>
           <ul>
             <li><a href="connect-add-key-to-source/kstreams.html">Add a key to a stream from a JDBC source</a></li>
-            <li><a href="kafka-connect-datagen-local/kafka.html">Generating data in a local cluster</a></li>
-            <li><a href="generate-streams-of-test-data/ksql.html">Generating complex data in a local cluster</a></li>
-            <li><a href="kafka-connect-datagen-ccloud/kafka.html">Generating data in Confluent Cloud</a></li>
+            <li><a href="kafka-connect-datagen-local/kafka.html">Generate data in a local cluster</a></li>
+            <li><a href="generate-streams-of-test-data/ksql.html">Generate complex data in a local cluster</a></li>
+            <li><a href="kafka-connect-datagen-ccloud/kafka.html">Generate data in Confluent Cloud</a></li>
           </ul>
         </div>
        </div>
@@ -177,11 +177,11 @@
             <div>Access Fields</div>
           </div>
           <ul>
-            <li><a href="working-with-nested-json/ksql.html">Working with nested JSON</a></li>
-            <li><a href="working-with-json-different-structure/ksql.html">Working with heterogenous JSON</a></li>
+            <li><a href="working-with-nested-json/ksql.html">Nested JSON</a></li>
+            <li><a href="working-with-json-different-structure/ksql.html">Heterogenous JSON</a></li>
             <li><a href="transform-a-stream-of-events/ksql.html">Transform a stream of events</a></li>
             <li><a href="flatten-nested-data/ksql.html">Flatten deeply nested events</a></li>
-            <li><a href="geo-distance/ksql.html">Calculating lat-long distance</a></li>
+            <li><a href="geo-distance/ksql.html">Calculate lat-long distance</a></li>
           </ul>
         </div>
 
@@ -191,10 +191,10 @@
             <div>Manipulate Values</div>
           </div>
           <ul>
-            <li><a href="udf/ksql.html">Apply a user-defined function</a></li>
+            <li><a href="udf/ksql.html">User-defined functions (UDF)</a></li>
             <li><a href="concatenation/ksql.html">Concatenation</a></li>
-            <li><a href="masking-data/ksql.html">Masking data</a></li>
-            <li><a href="column-difference/ksql.html">Calculating column difference</a></li>
+            <li><a href="masking-data/ksql.html">Mask data</a></li>
+            <li><a href="column-difference/ksql.html">Calculate column difference</a></li>
           </ul>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
             <li><a href="kafka-console-consumer-primitive-keys-values/kafka.html">Primitive keys and values</a></li>
             <li><a href="message-ordering/kafka.html">Maintain message ordering</a></li>
             <li><a href="kafka-console-consumer-read-specific-offsets-partitions/kafka.html">Read from an offset and partition</a></li>
-            <li><a href="kafka-producer-callback-application/kafka.html">Callbacks</a></li>
             <li><a href="ccloud-produce-consume/kafka.html">Confluent Cloud CLI</a></li>
           </ul>
         </div>
@@ -55,6 +54,7 @@
           <ul>
             <li><a href="creating-first-apache-kafka-producer-application/kafka.html">Your first Kafka producer application</a></li>
             <li><a href="creating-first-apache-kafka-consumer-application/kafka.html">Your first Kafka consumer application</a></li>
+            <li><a href="kafka-producer-callback-application/kafka.html">Callbacks</a></li>
             <li><a href="produce-consume-lang/scala.html">Clients in multiple languages</a></li>
           </ul>
         </div>


### PR DESCRIPTION
### Description

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

- Maintain consistency in KT titles on the cards on the main KT page
- Moved ~2 KTs to a different card (this can be undone if anyone disagrees with the new placement)

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/card_titles_consistency/
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
