### PR TITLE
DEVX-2522: datagen KT: enhance with managed REST API

### DIFF
--- a/_data/harnesses/kafka-connect-datagen-ccloud/kafka.yml
+++ b/_data/harnesses/kafka-connect-datagen-ccloud/kafka.yml
@@ -43,6 +43,8 @@ dev:
           render:
             file: tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/provision-connector.adoc
 
+    - title: Verify the status of the connector in Confluent Cloud
+      content:
         - action: skip
           render:
             file: tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/check-connector.adoc

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector-rest.sh
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector-rest.sh
@@ -1,0 +1,1 @@
+curl -s -XGET -H 'Content-Type: application/json' --user $(cat cloud-api-key.json | jq -r '.key'):$(cat cloud-api-key.json | jq -r '.secret') https://api.confluent.cloud/connect/v1/environments/$ENVIRONMENT/clusters/$CLUSTER/connectors/datagen_ccloud_01/status | jq

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector-rest_expected.log
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector-rest_expected.log
@@ -1,0 +1,17 @@
+{
+  "name": "datagen_ccloud_01",
+  "connector": {
+    "state": "RUNNING",
+    "worker_id": "datagen_ccloud_01",
+    "trace": ""
+  },
+  "tasks": [
+    {
+      "id": 0,
+      "state": "RUNNING",
+      "worker_id": "datagen_ccloud_01",
+      "msg": ""
+    }
+  ],
+  "type": "source"
+}

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/create-cloud-api-key.sh
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/create-cloud-api-key.sh
@@ -1,0 +1,1 @@
+ccloud api-key create --resource cloud -o json > cloud-api-key.json

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/create-connector-rest.sh
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/create-connector-rest.sh
@@ -1,0 +1,1 @@
+curl -XPUT -H 'Content-Type: application/json' --data "@datagen-source-config.json" --user $(cat cloud-api-key.json | jq -r '.key'):$(cat cloud-api-key.json | jq -r '.secret') https://api.confluent.cloud/connect/v1/environments/$ENVIRONMENT/clusters/$CLUSTER/connectors/datagen_ccloud_01/config

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/check-connector.adoc
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/check-connector.adoc
@@ -14,6 +14,8 @@ Rerun this command to get the updated Status, it will change from `PROVISIONING`
 
 *Option 2.* The Confluent Cloud REST API provides a `connector_name/status` endpoint you can use to verify the status of a provisioned connector. Note the `connector.state` field in the returned JSON.
 
+As described in Step 7 above, an API Key is required for all REST API calls to succeed.
+
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector-rest.sh %}</code></pre>
 +++++

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/check-connector.adoc
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/check-connector.adoc
@@ -1,11 +1,23 @@
-Check the status of the connector:
+To check the status of the connector from the command line, you have the same two options as provisioning.
+
+*Option 1.* Using the `ccloud` CLI.
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector.sh %}</code></pre>
 +++++
 
-After a minute or two, rerun this command to get the updated Status, it will change from `PROVISIONING` to `RUNNING` when the Connector is ready.
+Rerun this command to get the updated Status, it will change from `PROVISIONING` to `RUNNING` when the Connector is ready.
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector_expected.log %}</code></pre>
++++++
+
+*Option 2.* The Confluent Cloud REST API provides a `connector_name/status` endpoint you can use to verify the status of a provisioned connector. Note the `connector.state` field in the returned JSON.
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector-rest.sh %}</code></pre>
++++++
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/check-connector-rest_expected.log %}</code></pre>
 +++++

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/clean-up.adoc
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/clean-up.adoc
@@ -5,3 +5,5 @@ Pass in the `SERVICE_ACCOUNT_ID` that was generated when the `ccloud-stack` was 
 +++++
 <pre class="snippet"><code class="groovy">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/clean-up.sh %}</code></pre>
 +++++
+
+See the Confluent Cloud link:https://docs.confluent.io/ccloud-cli/current/index.html[CLI] and link:https://docs.confluent.io/cloud/current/api.html[REST API] documentation for full details on operating managed connectors.

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/create-connector-config.adoc
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/create-connector-config.adoc
@@ -1,4 +1,4 @@
-You can provision the Kafka Connect Datagen connector through the Confluent Cloud UI, but this tutorial uses the Confluent Cloud CLI.
+You can provision the Kafka Connect Datagen connector through the Confluent Cloud UI, but in this tutorial you can choose to use the Confluent Cloud CLI or the link:https://docs.confluent.io/cloud/current/api.html[Confluent Cloud REST API].
 
 First, create a file called `datagen-source-config.json` with the below connector configuration for the Kafka Connect Datagen source connector for Confluent Cloud.
 Substitute `<API KEY>` and `<API SECRET>` with the credentials created by `ccloud-stack`.

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/provision-connector.adoc
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/provision-connector.adoc
@@ -1,6 +1,23 @@
-Provision the Kafka Connect Datagen source connector with the following command.
-Notice that it references the connector configuration file `datagen-source-config.json` that you created in the previous step.
+You can choose one of two options for provisioning a fully managed Kafka Connect Datagen source connector in Confluent Cloud.  Either option will use the connector configuration file `datagen-source-config.json` that you created in the previous step.
+
+*Option 1.* You can use the Confluent Cloud CLI which provides the `ccloud connector create` command allowing you to pass in the configuration file from the previous step. The `ccloud` CLI is already logged in the `ccloud_library` configured it to use a newly created environment and Kafka cluster.
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/create-connector.sh %}</code></pre>
++++++
+
+*Option 2.* The Confluent Cloud REST API can provision the connector using the configuration file you created from the previous step. This API requires we provide a Confluent Cloud resource ID for both the environment and Kafka cluster we wish to deploy the connector to. These values can be obtained by using the link:https://confluent.cloud/environments[Confluent Cloud UI] or using the `ccloud kafka cluster describe` link:https://docs.confluent.io/ccloud-cli/current/command-reference/kafka/cluster/ccloud_kafka_cluster_describe.html[command]. When using `ccloud_library.sh`, as we did above, the script sets two environment variables (`ENVIRONMENT` and `CLUSTER`) with these values.
+
+Additionally, we must provide an API Key and Secret which authorizes us to control our cloud account. This API key is independent of the one you use to connect to Kafka or the Schema Registry, so we need to generate it before the HTTP command will succeed.
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/create-cloud-api-key.sh %}</code></pre>
++++++
+
+The `cloud-api-key.json` file now contains an API key and secret authorized to control your cloud account. Protect this file as you would any secret value. 
+
+The following `curl` command will read the API key and secret from the `cloud-api-key.json` file (using the link:https://stedolan.github.io/jq/[jq dev tool]) and `PUT` the new connector config to the REST API in the appropriate environment and Kafka cluster.
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen-ccloud/kafka/code/tutorial-steps/dev/create-connector-rest.sh %}</code></pre>
 +++++

--- a/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/setup-ccloud.adoc
+++ b/_includes/tutorials/kafka-connect-datagen-ccloud/kafka/markup/dev/setup-ccloud.adoc
@@ -1,6 +1,6 @@
 We recommend you run this tutorial in a new Confluent Cloud environment so it doesn't interfere with your other work, and the easiest way to do this is to use the `ccloud-stack` utility.
 This provisions a new Confluent Cloud stack with a new environment, a new service account, a new Kafka cluster and associated credentials, enables Schema Registry and associated credentials, ACLs with wildcard for the service account, and a local configuration file with all above connection information.
-For more information on `ccloud-stack`, read the link:https://github.com/confluentinc/examples/blob/latest/ccloud/ccloud-stack/README.md[documentation].
+For more information on `ccloud-stack`, see the link:https://github.com/confluentinc/examples/blob/latest/ccloud/ccloud-stack/README.md[documentation].
 
 
 Get the open source library link:https://github.com/confluentinc/examples/blob/latest/utils/ccloud_library.sh[ccloud_library.sh] which has functions to interact with Confluent Cloud, including `ccloud-stack`.


### PR DESCRIPTION
### Description

Include the options to deploy and view the datage connector using the REST APIs
in addition to the already present ccloud versions of the command


### Staging Docs
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/DEVX-2522/kafka-connect-datagen-ccloud/kafka.html
