### PR TITLE
Golden KT example

### DIFF
--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -7,30 +7,23 @@ dev:
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/init.adoc
 
-    - title: Get Confluent Platform
+    - title: Get Confluent Cloud and the CLI
       content:
-        - action: make_file
-          file: docker-compose.yml
+        - action: skip
           render:
-            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-docker-compose.adoc
+            file: _includes/shared/markup/ccloud/get-ccloud.adoc
 
-        - action: execute_async
-          file: tutorial-steps/dev/docker-compose-up.sh
+    - title: Provision resources in Confluent Cloud
+      content:
+        - action: skip
           render:
-            file: tutorials/kafka-consumer-application/kafka/markup/dev/start-compose.adoc
-
-        - action: execute
-          file: tutorial-steps/dev/wait-for-containers.sh
-          render:
-            skip: true
+            file: shared/markup/ccloud/ccloud-setup-self.adoc
 
     - title: Create a topic
       content:
-        - action: execute
-          file: tutorial-steps/dev/harness-create-topic.sh
+        - action: skip
           render:
-            file: tutorials/kafka-consumer-application/kafka/markup/dev/create-topic.adoc
-            
+            file: tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
 
     - title: Configure the project
       content:
@@ -49,10 +42,9 @@ dev:
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/make-config-dir.adoc
 
-        - action: make_file
-          file: configuration/dev.properties
+        - action: skip
           render:
-            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-dev-file.adoc
+            file: tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
             
 
     - title: Create the Kafka Consumer Application
@@ -93,11 +85,9 @@ dev:
 
     - title: Produce sample data to the input topic
       content:
-        - action: execute
-          file: tutorial-steps/dev/harness-console-producer.sh
-          stdin: tutorial-steps/dev/input.txt
+        - action: skip
           render:
-            file: tutorials/kafka-consumer-application/kafka/markup/dev/run-producer.adoc
+            file: tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
 
     - title: Inspect the consumed records
       content:
@@ -170,11 +160,3 @@ prod:
           file: tutorial-steps/dev/clean-up.sh
           render:
             skip: true
-
-ccloud:
-  steps:
-    - title: Run your app to Confluent Cloud
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/try-ccloud-properties.adoc

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -7,6 +7,11 @@ dev:
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/init.adoc
 
+        - action: execute
+          file: tutorial-steps/dev/make-configuration-dir.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-config-dir.adoc
+
     - title: Sign up for Confluent Cloud and Get the CLI
       content:
         - action: skip
@@ -42,11 +47,6 @@ dev:
           file: tutorial-steps/dev/gradle-wrapper.sh
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/make-gradle-wrapper.adoc
-
-        - action: execute
-          file: tutorial-steps/dev/make-configuration-dir.sh
-          render:
-            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-config-dir.adoc
 
         - action: skip
           render:

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -11,7 +11,7 @@ dev:
       content:
         - action: skip
           render:
-            file: _includes/shared/markup/ccloud/get-ccloud.adoc
+            file: shared/markup/ccloud/get-ccloud.adoc
 
     - title: Provision resources in Confluent Cloud
       content:

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -24,7 +24,7 @@ dev:
           render:
             file: shared/markup/ccloud/ccloud-setup-self.adoc
 
-    - title: Create a config file with Confluent Cloud resource information
+    - title: Create a config file with Confluent Cloud information
       content:
         - action: skip
           render:

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -44,6 +44,10 @@ dev:
 
         - action: skip
           render:
+            file: shared/markup/ccloud/config-create.adoc
+
+        - action: skip
+          render:
             file: tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
             
 

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -7,7 +7,7 @@ dev:
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/init.adoc
 
-    - title: Get Confluent Cloud and the CLI
+    - title: Sign up for Confluent Cloud and Get the CLI
       content:
         - action: skip
           render:

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -19,6 +19,12 @@ dev:
           render:
             file: shared/markup/ccloud/ccloud-setup-self.adoc
 
+    - title: Create a config file with Confluent Cloud resource information
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/config-create.adoc
+
     - title: Create a topic
       content:
         - action: skip
@@ -44,12 +50,13 @@ dev:
 
         - action: skip
           render:
-            file: shared/markup/ccloud/config-create.adoc
+            file: tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
 
+    - title: Update the client config file with Confluent Cloud information
+      content:
         - action: skip
           render:
-            file: tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
-            
+            file: shared/markup/ccloud/append-ccloud-config.adoc
 
     - title: Create the Kafka Consumer Application
       content:

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -12,12 +12,6 @@ dev:
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/make-config-dir.adoc
 
-    - title: Sign up for Confluent Cloud and Get the CLI
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/get-ccloud.adoc
-
     - title: Provision resources in Confluent Cloud
       content:
         - action: skip
@@ -29,6 +23,12 @@ dev:
         - action: skip
           render:
             file: shared/markup/ccloud/config-create.adoc
+
+    - title: Download and setup the Confluent Cloud CLI
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/get-ccloud.adoc
 
     - title: Create a topic
       content:

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -97,6 +97,11 @@ dev:
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/print-consumer-file-results.adoc
 
+    - title: Teardown Confluent Cloud resources
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-destroy.adoc
 
 test:
   steps:

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -1,0 +1,180 @@
+dev:
+  steps:
+    - title: Initialize the project
+      content:
+        - action: execute
+          file: tutorial-steps/dev/init.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/init.adoc
+
+    - title: Get Confluent Platform
+      content:
+        - action: make_file
+          file: docker-compose.yml
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-docker-compose.adoc
+
+        - action: execute_async
+          file: tutorial-steps/dev/docker-compose-up.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/start-compose.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/wait-for-containers.sh
+          render:
+            skip: true
+
+    - title: Create a topic
+      content:
+        - action: execute
+          file: tutorial-steps/dev/harness-create-topic.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/create-topic.adoc
+            
+
+    - title: Configure the project
+      content:
+        - action: make_file
+          file: build.gradle
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-build-file.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/gradle-wrapper.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-gradle-wrapper.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/make-configuration-dir.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-config-dir.adoc
+
+        - action: make_file
+          file: configuration/dev.properties
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-dev-file.adoc
+            
+
+    - title: Create the Kafka Consumer Application
+      content:
+        - action: execute
+          file: tutorial-steps/dev/make-src-dir.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-src-dir.adoc
+            
+        - action: make_file
+          file: src/main/java/io/confluent/developer/KafkaConsumerApplication.java
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-consumer-app.adoc 
+
+    - title: Create supporting classes
+      content:
+        - action: make_file
+          file: src/main/java/io/confluent/developer/ConsumerRecordsHandler.java
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/make-supporting-classes.adoc 
+
+        - action: make_file
+          file: src/main/java/io/confluent/developer/FileWritingRecordsHandler.java
+          render:
+            skip: true
+
+    - title: Compile and run the Kafka Consumer program
+      content:
+        - action: execute
+          file: tutorial-steps/dev/build-uberjar.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/build-uberjar.adoc
+
+        - action: execute_async
+          file: tutorial-steps/dev/run-dev-app.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/run-dev-app.adoc
+
+    - title: Produce sample data to the input topic
+      content:
+        - action: execute
+          file: tutorial-steps/dev/harness-console-producer.sh
+          stdin: tutorial-steps/dev/input.txt
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/run-producer.adoc
+
+    - title: Inspect the consumed records
+      content:
+        - action: execute
+          file: tutorial-steps/dev/print-consumer-file-results.sh
+          stdout: tutorial-steps/dev/outputs/actual-output.txt
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/dev/print-consumer-file-results.adoc
+
+
+test:
+  steps:
+    - title: Create a test configuration file
+      content:
+        - action: make_file
+          file: configuration/test.properties
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/test/make-test-file.adoc
+
+    - title: Write a test for the consumer application
+      content:
+        - action: execute
+          file: tutorial-steps/test/make-test-dir.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/test/make-test-dir.adoc
+
+        - action: make_file
+          file: src/test/java/io/confluent/developer/KafkaConsumerApplicationTest.java
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/test/make-consumer-applicaion-test.adoc
+
+    - title: Write a test for the records ConsumerRecordsHandler
+      content:
+        - action: make_file
+          file: src/test/java/io/confluent/developer/FileWritingRecordsHandlerTest.java
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/test/make-consumer-records-handler-test.adoc
+
+
+    - title: Invoke the tests
+      content:
+        - action: execute
+          file: tutorial-steps/test/invoke-tests.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/test/invoke-tests.adoc
+
+prod:
+  steps:
+    - title: Create a production configuration file
+      content:
+        - action: make_file
+          file: configuration/prod.properties
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/prod/make-prod-file.adoc
+
+    - title: Build a Docker image
+      content:
+        - action: execute
+          file: tutorial-steps/prod/build-image.sh
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/prod/build-image.adoc
+
+    - title: Launch the container
+      content:
+        - action: skip
+          render:
+            file: tutorials/kafka-consumer-application/kafka/markup/prod/launch-container.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/clean-up.sh
+          render:
+            skip: true
+
+ccloud:
+  steps:
+    - title: Run your app to Confluent Cloud
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/try-ccloud-properties.adoc

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -12,7 +12,7 @@ dev:
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/make-config-dir.adoc
 
-    - title: Provision resources in Confluent Cloud
+    - title: Sign up for Confluent Cloud and provision resources
       content:
         - action: skip
           render:

--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -358,6 +358,7 @@ kafka-consumer-application:
     ksql: disabled
     kstreams: disabled
     kafka: enabled
+    confluent: enabled
 
 produce-consume-lang:
   title: "Produce and Consume Records in non-Java languages"

--- a/_includes/shared/code/ccloud/cat-config.sh
+++ b/_includes/shared/code/ccloud/cat-config.sh
@@ -1,0 +1,1 @@
+cat configuration/ccloud.properties >> configuration/dev.properties

--- a/_includes/shared/code/ccloud/ccloud-login.sh
+++ b/_includes/shared/code/ccloud/ccloud-login.sh
@@ -1,0 +1,1 @@
+ccloud login --save

--- a/_includes/shared/code/ccloud/ccloud-login.sh
+++ b/_includes/shared/code/ccloud/ccloud-login.sh
@@ -1,1 +1,0 @@
-ccloud login --save

--- a/_includes/shared/code/ccloud/config.properties
+++ b/_includes/shared/code/ccloud/config.properties
@@ -1,5 +1,5 @@
 # Required connection configs for Kafka producer, consumer, and admin
-bootstrap.servers={{ BOOTSTRAP SERVERS }}
+bootstrap.servers={{ BOOTSTRAP_SERVERS }}
 security.protocol=SASL_SSL
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule   required username='{{ CLUSTER_API_KEY }}'   password='{{ CLUSTER_API_SECRET }}';
 sasl.mechanism=PLAIN
@@ -10,6 +10,6 @@ client.dns.lookup=use_all_dns_ips
 acks=all
 
 # Required connection configs for Confluent Cloud Schema Registry
-schema.registry.url=https://psrc-pgpdo.us-east-2.aws.confluent.cloud
+schema.registry.url={{ SR_URL }}
 basic.auth.credentials.source=USER_INFO
 basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}

--- a/_includes/shared/code/ccloud/config.properties
+++ b/_includes/shared/code/ccloud/config.properties
@@ -1,5 +1,5 @@
 # Required connection configs for Kafka producer, consumer, and admin
-bootstrap.servers=pkc-4kgmg.us-west-2.aws.confluent.cloud:9092
+bootstrap.servers={{ BOOTSTRAP SERVERS }}
 security.protocol=SASL_SSL
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule   required username='{{ CLUSTER_API_KEY }}'   password='{{ CLUSTER_API_SECRET }}';
 sasl.mechanism=PLAIN

--- a/_includes/shared/code/ccloud/config.properties
+++ b/_includes/shared/code/ccloud/config.properties
@@ -1,0 +1,15 @@
+# Required connection configs for Kafka producer, consumer, and admin
+bootstrap.servers=pkc-4kgmg.us-west-2.aws.confluent.cloud:9092
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule   required username='{{ CLUSTER_API_KEY }}'   password='{{ CLUSTER_API_SECRET }}';
+sasl.mechanism=PLAIN
+# Required for correctness in Apache Kafka clients prior to 2.6
+client.dns.lookup=use_all_dns_ips
+
+# Best practice for Kafka producer to prevent data loss
+acks=all
+
+# Required connection configs for Confluent Cloud Schema Registry
+schema.registry.url=https://psrc-pgpdo.us-east-2.aws.confluent.cloud
+basic.auth.credentials.source=USER_INFO
+basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}

--- a/_includes/shared/markup/ccloud/append-ccloud-config.adoc
+++ b/_includes/shared/markup/ccloud/append-ccloud-config.adoc
@@ -1,2 +1,6 @@
 Append the contents of the `configuration/ccloud.properties` to `configuration/dev.properties`
-so that the application is able to connect to the Confluent Cloud cluster.
+so that the application is able to connect to the Confluent Cloud cluster with the command below.
+
++++++
+<pre class="snippet"><code class="bash">{% include_raw shared/code/ccloud/cat-config.sh %}</code></pre>
++++++

--- a/_includes/shared/markup/ccloud/append-ccloud-config.adoc
+++ b/_includes/shared/markup/ccloud/append-ccloud-config.adoc
@@ -1,0 +1,2 @@
+Append the contents of the `configuration/ccloud.properties` to `configuration/dev.properties`
+so that the application is able to connect to the Confluent Cloud cluster.

--- a/_includes/shared/markup/ccloud/ccloud-destroy.adoc
+++ b/_includes/shared/markup/ccloud/ccloud-destroy.adoc
@@ -1,1 +1,1 @@
-Now that we are done running this tutorial on Confluent Cloud, you may delete the Confluent Cloud resources created. This can be done in the Confluent Cloud UI, verify that all Confluent Cloud resources are destroyed to avoid unexpected charges.
+Go try another tutorial with your Confluent Cloud cluster. If you created new resources for the purposes of this tutorial and don't plan on doing other tutorials, you may want to destroy those resources. This can be done in the Confluent Cloud UI, verify that all Confluent Cloud resources are destroyed to avoid unexpected charges.

--- a/_includes/shared/markup/ccloud/ccloud-destroy.adoc
+++ b/_includes/shared/markup/ccloud/ccloud-destroy.adoc
@@ -1,0 +1,1 @@
+Now that we are done running this tutorial on Confluent Cloud, you may delete the Confluent Cloud resources created. This can be done in the Confluent Cloud UI, verify that all Confluent Cloud resources are destroyed to avoid unexpected charges.

--- a/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
+++ b/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
@@ -1,1 +1,1 @@
-From within the Confluent Cloud UI, click on `Learn` and follow the in-product instructions to launch Kafka and Schema Registry [and ksqlDB] or use the Confluent Cloud CLI.
+From within the https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud UI], click on `Learn` and follow the in-product instructions to launch Kafka and Schema Registry.

--- a/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
+++ b/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
@@ -1,1 +1,3 @@
 From within the https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud UI], click on `Learn` and follow the in-product instructions to launch Kafka and Schema Registry.
+Use the promo code `CC100KTS` to receive an additional $100 free usage on Confluent Cloud (https://www.confluent.io/confluent-cloud-promo-disclaimer[details]).
+

--- a/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
+++ b/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
@@ -1,3 +1,6 @@
-From within the https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud UI], click on `Learn` and follow the in-product instructions to launch Kafka and Schema Registry.
+From within the https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud UI], click on `Add cloud environment` and name it `kafka-learning`.
+This will keep your learning separate from other Confluent Cloud environments.
+
+Next click on `Learn` and follow the in-product instructions to launch Kafka and Schema Registry.
 Use the promo code `CC100KTS` to receive an additional $100 free usage on Confluent Cloud (https://www.confluent.io/confluent-cloud-promo-disclaimer[details]).
 

--- a/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
+++ b/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
@@ -1,0 +1,1 @@
+From within the Confluent Cloud UI, click on `Learn` and follow the in-product instructions to launch Kafka and Schema Registry [and ksqlDB] or use the Confluent Cloud CLI.

--- a/_includes/shared/markup/ccloud/config-create.adoc
+++ b/_includes/shared/markup/ccloud/config-create.adoc
@@ -1,8 +1,9 @@
-Create a development configuration file at `configuration/dev.properties` with your Confluent Cloud information.
+Create a development configuration file at `configuration/ccloud.properties` with your Confluent Cloud information.
 This file and the secrets it contains can be easily created using the Confluent Cloud UI. To do so, navigate to the
 ``Clients`` section in your cluster, click ``Create Kafka cluster API key & secret`` and ``Create Schema Registry API key & secret``,
-lastly select ``Java`` as the client. You should see something similar to below in the UI. Copy the contents of the configuration file and paste them into a
-`configuration/ccloud.properties` file on your local machine.
+lastly select ``Java`` as the client. Lastly make sure ``Show API keys`` is checked.
+You should see something similar to below in the UI. Copy the contents of the configuration file and paste them into a
+`cconfiguration/cloud.properties` file on your local machine.
 
 +++++
 <pre class="snippet"><code class="text">{% include_raw shared/code/ccloud/config.properties %}</code></pre>

--- a/_includes/shared/markup/ccloud/config-create.adoc
+++ b/_includes/shared/markup/ccloud/config-create.adoc
@@ -1,0 +1,9 @@
+Create a development configuration file at `configuration/dev.properties` with your Confluent Cloud information.
+This file and the secrets it contains can be easily created using the Confluent Cloud UI. To do so, navigate to the
+``Clients`` section in your cluster, click ``Create Kafka cluster API key & secret`` and ``Create Schema Registry API key & secret``,
+lastly select ``Java`` as the client. You should see something similar to below in the UI. Copy the contents of the configuration file and paste them into a
+`configuration/dev.properties` file on your local machine.
+
++++++
+<pre class="snippet"><code class="text">{% include_raw shared/code/ccloud/config.properties %}</code></pre>
++++++

--- a/_includes/shared/markup/ccloud/config-create.adoc
+++ b/_includes/shared/markup/ccloud/config-create.adoc
@@ -2,7 +2,7 @@ Create a development configuration file at `configuration/dev.properties` with y
 This file and the secrets it contains can be easily created using the Confluent Cloud UI. To do so, navigate to the
 ``Clients`` section in your cluster, click ``Create Kafka cluster API key & secret`` and ``Create Schema Registry API key & secret``,
 lastly select ``Java`` as the client. You should see something similar to below in the UI. Copy the contents of the configuration file and paste them into a
-`configuration/dev.properties` file on your local machine.
+`configuration/ccloud.properties` file on your local machine.
 
 +++++
 <pre class="snippet"><code class="text">{% include_raw shared/code/ccloud/config.properties %}</code></pre>

--- a/_includes/shared/markup/ccloud/config-create.adoc
+++ b/_includes/shared/markup/ccloud/config-create.adoc
@@ -1,7 +1,7 @@
 Create a development configuration file at `configuration/ccloud.properties` with your Confluent Cloud information.
 This file and the secrets it contains can be easily created using the Confluent Cloud UI. To do so, from the Confluent Cloud UI, navigate to the
 ``Clients`` section in your cluster, click ``Create Kafka cluster API key & secret`` and ``Create Schema Registry API key & secret``,
-lastly select ``Java`` as the client. Lastly make sure ``Show API keys`` is checked.
+and select ``Java`` as the client. Lastly make sure ``Show API keys`` is checked.
 You should see something similar to below in the UI. Copy the contents of the configuration file and paste them into a
 `cconfiguration/cloud.properties` file on your local machine.
 

--- a/_includes/shared/markup/ccloud/config-create.adoc
+++ b/_includes/shared/markup/ccloud/config-create.adoc
@@ -1,5 +1,5 @@
 Create a development configuration file at `configuration/ccloud.properties` with your Confluent Cloud information.
-This file and the secrets it contains can be easily created using the Confluent Cloud UI. To do so, navigate to the
+This file and the secrets it contains can be easily created using the Confluent Cloud UI. To do so, from the Confluent Cloud UI, navigate to the
 ``Clients`` section in your cluster, click ``Create Kafka cluster API key & secret`` and ``Create Schema Registry API key & secret``,
 lastly select ``Java`` as the client. Lastly make sure ``Show API keys`` is checked.
 You should see something similar to below in the UI. Copy the contents of the configuration file and paste them into a

--- a/_includes/shared/markup/ccloud/get-ccloud.adoc
+++ b/_includes/shared/markup/ccloud/get-ccloud.adoc
@@ -1,10 +1,2 @@
-If you don't have an account yet, sign up for link:https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]. 
-Use the promo code `CC100KTS` to receive an additional $100 free usage on Confluent Cloud (https://www.confluent.io/confluent-cloud-promo-disclaimer[details]).
-
-Install the link:https://docs.confluent.io/current/cloud/cli/install.html[Confluent Cloud CLI] and login with the command below using your Confluent Cloud username and password.
-
-+++++
-<pre class="snippet"><code class="text">{% include_raw shared/code/ccloud/ccloud-login.sh %}</code></pre>
-+++++
-
-The ``--save`` argument saves your Confluent Cloud user login credentials or refresh token (in the case of SSO) to the local ``netrc`` file.
+Download and setup the Confluent Cloud CLI. Instructions for this can be found within the Confluent Cloud UI,
+by navigating to your cluster, clicking on the `CLI and tools` section, and running through the steps in the `CCloud CLI` tab.

--- a/_includes/shared/markup/ccloud/get-ccloud.adoc
+++ b/_includes/shared/markup/ccloud/get-ccloud.adoc
@@ -1,0 +1,5 @@
+If you don't have an account yet, sign up for link:https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]. 
+Use the promo code `CC100KTS` to receive an additional $100 free usage on Confluent Cloud (https://www.confluent.io/confluent-cloud-promo-disclaimer[details]).
+
+Install the link:https://docs.confluent.io/current/cloud/cli/install.html[Confluent Cloud CLI] and login with the command ``ccloud login --save``, using your Confluent Cloud username and password.
+The ``--save`` argument saves your Confluent Cloud user login credentials or refresh token (in the case of SSO) to the local ``netrc`` file.

--- a/_includes/shared/markup/ccloud/get-ccloud.adoc
+++ b/_includes/shared/markup/ccloud/get-ccloud.adoc
@@ -1,5 +1,10 @@
 If you don't have an account yet, sign up for link:https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]. 
 Use the promo code `CC100KTS` to receive an additional $100 free usage on Confluent Cloud (https://www.confluent.io/confluent-cloud-promo-disclaimer[details]).
 
-Install the link:https://docs.confluent.io/current/cloud/cli/install.html[Confluent Cloud CLI] and login with the command ``ccloud login --save``, using your Confluent Cloud username and password.
+Install the link:https://docs.confluent.io/current/cloud/cli/install.html[Confluent Cloud CLI] and login with the command below using your Confluent Cloud username and password.
+
++++++
+<pre class="snippet"><code class="text">{% include_raw shared/code/ccloud/ccloud-login.sh %}</code></pre>
++++++
+
 The ``--save`` argument saves your Confluent Cloud user login credentials or refresh token (in the case of SSO) to the local ``netrc`` file.

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,0 +1,11 @@
+Using a terminal window, run the following command to start a Confluent Cloud CLI producer:
+
+```
+ccloud kafka topic produce input-topic
+```
+
+Each line represents input data for the KafkaConsumer application. To send all of the events below, paste the following into the prompt and press enter:
+
++++++
+<pre class="snippet"><code class="json">{% include_raw tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/input.txt %}</code></pre>
++++++

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
@@ -9,3 +9,5 @@ Each line represents input data for the KafkaConsumer application. To send all o
 +++++
 <pre class="snippet"><code class="json">{% include_raw tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/input.txt %}</code></pre>
 +++++
+
+Enter `Ctrl+C` to exit.

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
@@ -22,7 +22,7 @@ group.id=consumer-application
 file.path=consumer-records.out
 input.topic.name=input-topic
 input.topic.partitions=6
-input.topic.replication.factor=6
+input.topic.replication.factor=3
 ```
 
 Let's do a quick overview of some of the more important properties here:

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
@@ -1,0 +1,38 @@
+Then create a development configuration file at `configuration/dev.properties` with your Confluent Cloud information (specifically fill in the `bootstrap.servers`, `sasl.jaas.config`, `basic.auth.user.info`, and `schema.registry.url` configs):
+
+```
+# General cluster connection information
+security.protocol=SASL_SSL
+sasl.mechanism=PLAIN
+bootstrap.servers=<BROKER ENDPOINT>
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='<API KEY>' password='<API SECRET>';
+basic.auth.credentials.source=USER_INFO
+basic.auth.user.info=<SR API KEY>:<SR API SECRET>
+schema.registry.url=https://<SR ENDPOINT>
+
+# Consumer properties
+key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+max.poll.interval.ms=300000
+enable.auto.commit=true
+auto.offset.reset=earliest
+group.id=consumer-application
+
+# Application specific properties
+file.path=consumer-records.out
+input.topic.name=input-topic
+input.topic.partitions=6
+input.topic.replication.factor=6
+```
+
+Let's do a quick overview of some of the more important properties here:
+
+The `key.deserializer` and `value.deserializer` properties provide a class implementing the `Deserializer` interface for converting `byte` arrays into the expected object type of the key and value respectively.
+
+The `max.poll.interval.ms` is the maximum amount of time a consumer may take between calls to `Consumer.poll()`.  If a consumer instance takes longer than the specified time, it's considered non-responsive and removed from the consumer-group triggering a rebalance.
+
+Setting `enable.auto.commit` configuration to `true` enables the Kafka consumer to handle committing offsets automatically for you.  The default setting is `true`, but it's included here to make it explicit.  When you enable auto commit, you need to ensure you've processed all records _**before**_ the consumer calls `poll` again.  Once there is a subsequent call to `poll`, all the records returned from the previous call are considered processed and the consumer commits the offsets.
+
+`auto.offset.reset` - If a consumer instance can't locate any offsets for its topic-partition assignment(s), it will resume processing from the _**earliest**_ available offset.
+
+`group.id` - Kafka uses the concept of a consumer-group which is used to represent a logical single group.  A consumer-group can be made up of multiple members all sharing the same `group.id` configuration.  As members leave or join the consumer-group, the group-coordinator triggers a rebalance which causes topic-partition reassignment among active members of the group.

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
@@ -1,4 +1,4 @@
-Append the following to your `configuration/dev.properties` made above.
+Then create a development configuration file at `configuration/dev.properties`:
 
 ```
 # Consumer properties

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-config-file.adoc
@@ -1,15 +1,6 @@
-Then create a development configuration file at `configuration/dev.properties` with your Confluent Cloud information (specifically fill in the `bootstrap.servers`, `sasl.jaas.config`, `basic.auth.user.info`, and `schema.registry.url` configs):
+Append the following to your `configuration/dev.properties` made above.
 
 ```
-# General cluster connection information
-security.protocol=SASL_SSL
-sasl.mechanism=PLAIN
-bootstrap.servers=<BROKER ENDPOINT>
-sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='<API KEY>' password='<API SECRET>';
-basic.auth.credentials.source=USER_INFO
-basic.auth.user.info=<SR API KEY>:<SR API SECRET>
-schema.registry.url=https://<SR ENDPOINT>
-
 # Consumer properties
 key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 value.deserializer=org.apache.kafka.common.serialization.StringDeserializer

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
@@ -1,0 +1,5 @@
+In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
+
+```
+ccloud kafka topic create input-topic
+```

--- a/tutorials/kafka-consumer-application/confluent/confluent.html
+++ b/tutorials/kafka-consumer-application/confluent/confluent.html
@@ -1,0 +1,6 @@
+---
+layout: tutorial
+permalink: /creating-first-apache-kafka-consumer-application/confluent
+stack: confluent
+static_data: kafka-consumer-application
+---


### PR DESCRIPTION
### Description
An example of converting a KT to run against CCloud. The KT chosen was the "kafka-consumer-application/kafka". This is a basic Kafka example. It follows the guidelines outlined in the [wiki for KT to CCloud conversions](https://confluentinc.atlassian.net/wiki/spaces/DEVX/pages/2150728976/Kafka+Tutorials+Nail+down+the+boiler+plate+to+provision+Confluent+Cloud#Summary-of-Decisions-for-Handling-Confluent-Cloud-in-Kafka-Tutorials).

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/stay-golden-KT/creating-first-apache-kafka-consumer-application/confluent.html
