### PR TITLE
MINOR: Remove Jcenter from build file

### DIFF
--- a/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -22,7 +22,7 @@ version = "0.0.1"
 mainClassName = "io.confluent.developer.RunningAverage"
 
 repositories {
-  jcenter()
+  
   maven { url 'https://packages.confluent.io/maven/' }
 }
 

--- a/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
@@ -22,7 +22,7 @@ version = "0.0.1"
 mainClassName = "io.confluent.developer.RunningAverage"
 
 repositories {
-  
+  mavenCentral()
   maven { url 'https://packages.confluent.io/maven/' }
 }
 

--- a/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -19,7 +19,7 @@ version = "0.0.1"
 
 repositories {
     mavenCentral()
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -19,7 +19,7 @@ version = "0.0.1"
 
 repositories {
     mavenCentral()
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -19,7 +19,7 @@ version = "0.0.1"
 
 repositories {
     mavenCentral()
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
@@ -2,7 +2,7 @@ import java.beans.EventSetDescriptor
 
 buildscript {
   repositories {
-    
+    mavenCentral()
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
@@ -2,7 +2,7 @@ import java.beans.EventSetDescriptor
 
 buildscript {
   repositories {
-    jcenter()
+    
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -21,7 +21,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-  jcenter()
+  
 
   maven {
     url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-  
+  mavenCentral()
 
   maven {
     url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -21,7 +21,7 @@ version = "0.0.1"
 
 repositories {
     mavenCentral()
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/filtering/kstreams/code/build.gradle
+++ b/_includes/tutorials/filtering/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -19,7 +19,7 @@ version = "0.0.1"
 
 repositories {
   mavenCentral()
-  jcenter()
+  
 
   maven {
     url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/finding-distinct/kstreams/code/build.gradle
+++ b/_includes/tutorials/finding-distinct/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -19,7 +19,7 @@ version = "0.0.1"
 
 repositories {
   mavenCentral()
-  jcenter()
+  
 
   maven {
     url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/fk-joins/kstreams/code/build.gradle
+++ b/_includes/tutorials/fk-joins/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+     mavenCentral()
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -19,7 +19,6 @@ version = "0.0.1"
 
 repositories {
   mavenCentral()
-  jcenter()
 
   maven {
     url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0'
@@ -19,7 +19,7 @@ version = '0.0.1'
 
 repositories {
   mavenCentral()
-  jcenter()
+  
 
   maven {
     url 'https://packages.confluent.io/maven'

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/build.gradle
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/build.gradle
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/merging/kstreams/code/build.gradle
+++ b/_includes/tutorials/merging/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -19,7 +19,7 @@ version = "0.0.1"
 
 repositories {
     mavenCentral()
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/message-ordering/kafka/code/build.gradle
+++ b/_includes/tutorials/message-ordering/kafka/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.github.jengelman.gradle.plugins:shadow:4.0.2"
@@ -18,7 +18,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/message-ordering/kafka/code/build.gradle
+++ b/_includes/tutorials/message-ordering/kafka/code/build.gradle
@@ -18,7 +18,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/rekeying-function/ksql/code/build.gradle
+++ b/_includes/tutorials/rekeying-function/ksql/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -14,7 +14,7 @@ version = '0.0.1'
 
 repositories {
     mavenCentral()
-    jcenter()
+    
 
     maven {
         url 'https://packages.confluent.io/maven'

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/code/build.gradle
@@ -19,8 +19,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
-
+    mavenCentral()
     maven {
         url "https://packages.confluent.io/maven"
     }

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.github.jengelman.gradle.plugins:shadow:6.0.0"
@@ -19,7 +19,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/serialization/kstreams/code/build.gradle
+++ b/_includes/tutorials/serialization/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -22,7 +22,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-  jcenter()
+  
 
   maven {
     url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/serialization/kstreams/code/build.gradle
+++ b/_includes/tutorials/serialization/kstreams/code/build.gradle
@@ -22,7 +22,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-  
+  mavenCentral()
 
   maven {
     url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/session-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/session-windows/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/session-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/session-windows/kstreams/code/build.gradle
@@ -20,8 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
-
+    mavenCentral()
     maven {
         url "https://packages.confluent.io/maven"
     }

--- a/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/splitting/kstreams/code/build.gradle
+++ b/_includes/tutorials/splitting/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -19,7 +19,7 @@ version = "0.0.1"
 
 repositories {
   mavenCentral()
-  jcenter()
+  
 
   maven {
     url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/time-concepts/ksql/code/build.gradle
+++ b/_includes/tutorials/time-concepts/ksql/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.21.0"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/time-concepts/ksql/code/build.gradle
+++ b/_includes/tutorials/time-concepts/ksql/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/transforming/kafka/code/build.gradle
+++ b/_includes/tutorials/transforming/kafka/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0'
@@ -20,7 +20,7 @@ version = '0.0.1'
 
 repositories {
   mavenCentral()
-  jcenter()
+  
 
   maven {
     url 'https://packages.confluent.io/maven'

--- a/_includes/tutorials/transforming/kstreams/code/build.gradle
+++ b/_includes/tutorials/transforming/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0'
@@ -19,7 +19,7 @@ version = '0.0.1'
 
 repositories {
   mavenCentral()
-  jcenter()
+  
 
   maven {
     url 'https://packages.confluent.io/maven'

--- a/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0'
@@ -19,7 +19,7 @@ version = '0.0.1'
 
 repositories {
   mavenCentral()
-  jcenter()
+  
 
   maven {
     url 'https://packages.confluent.io/maven'

--- a/_includes/tutorials/udf/ksql/code/build.gradle
+++ b/_includes/tutorials/udf/ksql/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -14,7 +14,7 @@ version = "0.0.1"
 
 repositories {
     mavenCentral()
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/window-final-result/kstreams/code/build.gradle
+++ b/_includes/tutorials/window-final-result/kstreams/code/build.gradle
@@ -14,7 +14,7 @@ version = "0.0.1-SNAPSHOT"
 mainClassName = "io.confluent.developer.WindowFinalResult"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/window-final-result/kstreams/code/build.gradle
+++ b/_includes/tutorials/window-final-result/kstreams/code/build.gradle
@@ -14,7 +14,7 @@ version = "0.0.1-SNAPSHOT"
 mainClassName = "io.confluent.developer.WindowFinalResult"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/templates/kstreams/filtered/code/build.gradle
+++ b/templates/kstreams/filtered/code/build.gradle
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/templates/kstreams/filtered/code/build.gradle
+++ b/templates/kstreams/filtered/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.15.1"
@@ -20,7 +20,7 @@ targetCompatibility = "1.8"
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    
 
     maven {
         url "https://packages.confluent.io/maven"


### PR DESCRIPTION
### Description

JCenter is shutting down - https://blog.gradle.org/jcenter-shutdown.  All of the KS tutorials use `jcenter` in the `build.gradle` file.  This PR has one change to use `mavenCentral` instead.  