### PR TITLE
CCloudify Tumbling Windows

### DIFF
--- a/_data/harnesses/tumbling-windows/confluent.yml
+++ b/_data/harnesses/tumbling-windows/confluent.yml
@@ -1,0 +1,191 @@
+dev:
+  steps:
+    - title: Initialize the project
+      content:
+        - action: execute
+          file: tutorial-steps/dev/init.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/init.adoc
+
+        - action: skip
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/make-config-dir.adoc
+
+    - title: Sign up for Confluent Cloud and provision resources
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-setup-self.adoc
+
+    - title: Create a properties file with Confluent Cloud information
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/config-create.adoc
+
+    - title: Download and setup the Confluent Cloud CLI
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/get-ccloud.adoc
+
+    - title: Configure the project
+      content:
+        - action: make_file
+          file: build.gradle
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/make-build-file.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/gradle-wrapper.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/make-gradle-wrapper.adoc
+
+        - action: make_file
+          file: configuration/dev.properties
+          render:
+            file: tutorials/tumbling-windows/confluent/markup/dev/make-dev-file.adoc
+
+    - title: Update the properties file with Confluent Cloud information
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/append-ccloud-config.adoc
+        
+    - title: Create a schema for the events
+      content:
+        - action: execute
+          file: tutorial-steps/dev/make-avro-dir.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/make-avro-dir.adoc
+
+        - action: make_file
+          file: src/main/avro/rating.avsc
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/make-rating-schema.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/build-project.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/build-project.adoc
+
+    - title: Create the Kafka Streams topology
+      content:
+        - action: execute
+          file: tutorial-steps/dev/make-src-dir.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/make-src-dir.adoc
+
+        - action: make_file
+          file: src/main/java/io/confluent/developer/TumblingWindow.java
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/make-topology.adoc
+
+    - title: Implement a TimestampExtractor class
+      content:
+        - action: make_file
+          file: src/main/java/io/confluent/developer/RatingTimestampExtractor.java
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/make-extractor.adoc
+
+    - title: Some special configuration
+      content:
+        - action: skip
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/config-explanation.adoc
+
+    - title: Compile and run the Kafka Streams program
+      content:
+        - action: execute
+          file: tutorial-steps/dev/build-uberjar.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/build-uberjar.adoc
+
+        - action: execute_async
+          file: tutorial-steps/dev/run-dev-app.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/dev/run-dev-app.adoc
+
+    - title: Get ready to observe the counted ratings in the output topic
+      content:
+        - action: execute_async
+          file: tutorial-steps/dev/console-consumer.sh
+          stdout: tutorial-steps/dev/outputs/windowed-ratings-actual.txt
+          render:
+            file: tutorials/tumbling-windows/confluent/markup/dev/run-consumer.adoc
+
+    - title: Produce some ratings to the input topic
+      content:
+        - action: execute
+          file: tutorial-steps/dev/console-producer-ratings.sh
+          stdin: tutorial-steps/dev/ratings.json
+          render:
+            file: tutorials/tumbling-windows/confluent/markup/dev/run-producer.adoc
+
+    - title: Teardown Confluent Cloud resources
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-destroy.adoc
+
+test:
+  steps:
+    - title: Create a test configuration file
+      content:
+        - action: make_file
+          file: configuration/test.properties
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/test/make-test-file.adoc
+
+    - title: Test the RatingTimestampExtractor class
+      content:
+        - action: execute
+          file: tutorial-steps/test/make-test-dir.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/test/make-test-dir.adoc
+
+        - action: make_file
+          file: src/test/java/io/confluent/developer/RatingTimestampExtractorTest.java
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/test/make-extractor-test.adoc
+
+    - title: Test the streams topology
+      content:
+        - action: make_file
+          file: src/test/java/io/confluent/developer/TumblingWindowTest.java
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/test/make-topology-test.adoc
+
+    - title: Invoke the tests
+      content:
+        - action: execute
+          file: tutorial-steps/test/invoke-tests.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/test/invoke-tests.adoc
+
+prod:
+  steps:
+    - title: Create a production configuration file
+      content:
+        - action: make_file
+          file: configuration/prod.properties
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/prod/make-prod-file.adoc
+
+    - title: Build a Docker image
+      content:
+        - action: execute
+          file: tutorial-steps/prod/build-image.sh
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/prod/build-image.adoc
+
+    - title: Launch the container
+      content:
+        - action: skip
+          render:
+            file: tutorials/tumbling-windows/kstreams/markup/prod/launch-container.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/clean-up.sh
+          render:
+            skip: true

--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -110,6 +110,7 @@ tumbling-windows:
   status:
     ksql: enabled
     kstreams: enabled
+    confluent: enabled
 
 hopping-windows:
   title: "How to create hopping windows"

--- a/_includes/tutorials/tumbling-windows/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/tumbling-windows/confluent/code/configuration/dev.properties
@@ -1,0 +1,9 @@
+application.id=tumbling-window-app
+
+rating.topic.name=ratings
+rating.topic.partitions=6
+rating.topic.replication.factor=3
+
+rating.count.topic.name=rating-counts
+rating.count.topic.partitions=6
+rating.count.topic.replication.factor=3

--- a/_includes/tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-consumer.sh
@@ -1,0 +1,1 @@
+ccloud kafka topic consume rating-counts -b --print-key

--- a/_includes/tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-producer-ratings.sh
+++ b/_includes/tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-producer-ratings.sh
@@ -1,0 +1,1 @@
+ccloud kafka topic produce rating --value-format avro --schema src/main/avro/rating.avsc

--- a/_includes/tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-producer-ratings.sh
+++ b/_includes/tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-producer-ratings.sh
@@ -1,1 +1,1 @@
-ccloud kafka topic produce rating --value-format avro --schema src/main/avro/rating.avsc
+ccloud kafka topic produce ratings --value-format avro --schema src/main/avro/rating.avsc

--- a/_includes/tutorials/tumbling-windows/confluent/markup/dev/make-dev-file.adoc
+++ b/_includes/tutorials/tumbling-windows/confluent/markup/dev/make-dev-file.adoc
@@ -1,0 +1,5 @@
+Then create a development file at `configuration/dev.properties`:
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/tumbling-windows/confluent/code/configuration/dev.properties %}</code></pre>
++++++

--- a/_includes/tutorials/tumbling-windows/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/tumbling-windows/confluent/markup/dev/run-consumer.adoc
@@ -1,0 +1,7 @@
+Before you start producing input data, it's a good idea to set up the consumer on the output topic. This way, as soon as you produce movie ratings (and windowed and counted), you'll see the results right away. Run this to get ready to consume the windowed counts:
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-consumer.sh %}</code></pre>
++++++
+
+You won't see any results until the next step.

--- a/_includes/tutorials/tumbling-windows/confluent/markup/dev/run-producer.adoc
+++ b/_includes/tutorials/tumbling-windows/confluent/markup/dev/run-producer.adoc
@@ -1,0 +1,25 @@
+When the console producer starts, it will log some text and hang, waiting for your input. You can copy and paste all of the test data at once to see the results. (Because event times are baked into each message, it doesn't matter at what time the messages arrive in the input topic. In fact, if you want extra credit, you should be able to experiment with changing the order of the messages in this data, and still get the same output counts.)
+
+Start the console producer with this command in a terminal window of its own:
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-producer-ratings.sh %}</code></pre>
++++++
+
+
+When the producer starts up, copy and paste these lines into the terminal:
+
++++++
+<pre class="snippet"><code class="json">{% include_raw tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/ratings.json %}</code></pre>
++++++
+
+Looking back up in the consumer terminal, these are the results you should see there if you paste in all the ratings as directed above:
+
++++++
+<pre class="snippet"><code class="json">{% include_raw tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/windowed-counted-ratings.txt %}</code></pre>
++++++
+
+Note that each event is counted individually. Since output caching is disabled, we see Die Hard get counted once, then counted again, then counted again, until the Die Hard ratings stop arriving. At that point, we have the final count for that movie. The same happens with all the rest. If we were to interrogate the contents of the resulting `KTable` after all the input messages have arrived, we would see only the final counts in the table—not the history of the counting as we see in the output topic. This is a good illustration of what we sometimes refer to as the _stream-table duality_.
+
+
+That is a topic for further study later on, but for now, you deserve some congratulations! You have now computed an aggregation over a tumbling window. Well done.

--- a/_includes/tutorials/tumbling-windows/confluent/markup/dev/run-producer.adoc
+++ b/_includes/tutorials/tumbling-windows/confluent/markup/dev/run-producer.adoc
@@ -6,6 +6,13 @@ Start the console producer with this command in a terminal window of its own:
 <pre class="snippet"><code class="shell">{% include_raw tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-producer-ratings.sh %}</code></pre>
 +++++
 
+You will be prompted for the Confluent Cloud Schema Registry credentials as shown below, which you can find in the `configuration/ccloud.properties` configuration file.
+Look for the configuration parameter `basic.auth.user.info`, whereby the ":" is the delimiter between the key and secret.
+
+```
+Enter your Schema Registry API key:
+Enter your Schema Registry API secret:
+```
 
 When the producer starts up, copy and paste these lines into the terminal:
 

--- a/_includes/tutorials/tumbling-windows/kstreams/code/src/main/java/io/confluent/developer/TumblingWindow.java
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/src/main/java/io/confluent/developer/TumblingWindow.java
@@ -81,8 +81,10 @@ public class TumblingWindow {
     private SpecificAvroSerde<Rating> ratedMovieAvroSerde(final Properties allProps) {
         final SpecificAvroSerde<Rating> movieAvroSerde = new SpecificAvroSerde<>();
 
-        final Map<String, String> serdeConfig = (Map)allProps;
-        movieAvroSerde.configure(serdeConfig, false);
+        Map<String, String> config = new HashMap<>();
+        for (final String name: allProps.stringPropertyNames())
+                    config.put(name, allProps.getProperty(name));
+        movieAvroSerde.configure(config, false);
         return movieAvroSerde;
     }
 

--- a/_includes/tutorials/tumbling-windows/kstreams/code/src/test/java/io/confluent/developer/TumblingWindowTest.java
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/src/test/java/io/confluent/developer/TumblingWindowTest.java
@@ -31,7 +31,9 @@ public class TumblingWindowTest {
     private SpecificAvroSerializer<Rating> makeRatingSerializer(Properties allProps) {
         SpecificAvroSerializer<Rating> serializer = new SpecificAvroSerializer<>();
 
-        final Map<String, String> config = (Map)allProps;
+        Map<String, String> config = new HashMap<>();
+        for (final String name: allProps.stringPropertyNames())
+                    config.put(name, allProps.getProperty(name));
         serializer.configure(config, false);
 
         return serializer;

--- a/_includes/tutorials/tumbling-windows/kstreams/code/src/test/java/io/confluent/developer/TumblingWindowTest.java
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/src/test/java/io/confluent/developer/TumblingWindowTest.java
@@ -28,11 +28,10 @@ public class TumblingWindowTest {
     private TopologyTestDriver testDriver;
 
 
-    private SpecificAvroSerializer<Rating> makeRatingSerializer(Properties envProps) {
+    private SpecificAvroSerializer<Rating> makeRatingSerializer(Properties allProps) {
         SpecificAvroSerializer<Rating> serializer = new SpecificAvroSerializer<>();
 
-        Map<String, String> config = new HashMap<>();
-        config.put("schema.registry.url", envProps.getProperty("schema.registry.url"));
+        final Map<String, String> config = (Map)allProps;
         serializer.configure(config, false);
 
         return serializer;
@@ -54,17 +53,16 @@ public class TumblingWindowTest {
     @Test
     public void testWindows() throws IOException {
         TumblingWindow tw = new TumblingWindow();
-        Properties envProps = tw.loadEnvProperties(TEST_CONFIG_FILE);
-        Properties streamProps = tw.buildStreamsProperties(envProps);
+        Properties allProps = tw.buildStreamsProperties(tw.loadEnvProperties(TEST_CONFIG_FILE));
 
-        String inputTopic = envProps.getProperty("rating.topic.name");
-        String outputTopic = envProps.getProperty("rating.count.topic.name");
+        String inputTopic = allProps.getProperty("rating.topic.name");
+        String outputTopic = allProps.getProperty("rating.count.topic.name");
 
-        Topology topology = tw.buildTopology(envProps);
-        testDriver = new TopologyTestDriver(topology, streamProps);
+        Topology topology = tw.buildTopology(allProps);
+        testDriver = new TopologyTestDriver(topology, allProps);
 
         Serializer<String> stringSerializer = Serdes.String().serializer();
-        SpecificAvroSerializer<Rating> ratingSerializer = makeRatingSerializer(envProps);
+        SpecificAvroSerializer<Rating> ratingSerializer = makeRatingSerializer(allProps);
         Deserializer<String> stringDeserializer = Serdes.String().deserializer();
 
         List<Rating> ratings = new ArrayList<>();

--- a/settings.gradle
+++ b/settings.gradle
@@ -68,6 +68,7 @@ include '_includes:tutorials:streams-to-table:kstreams:code'
 include '_includes:tutorials:transforming:kafka:code'
 include '_includes:tutorials:transforming:kstreams:code'
 include '_includes:tutorials:tumbling-windows:kstreams:code'
+include '_includes:tutorials:tumbling-windows:confluent:code'
 // udf is an exception
 include '_includes:tutorials:udf:ksql:code'
 include '_includes:tutorials:window-final-result:kstreams:code'

--- a/tutorials/tumbling-windows/confluent.html
+++ b/tutorials/tumbling-windows/confluent.html
@@ -1,0 +1,6 @@
+---
+layout: tutorial
+permalink: /create-tumbling-windows/confluent
+stack: confluent
+static_data: tumbling-windows
+---


### PR DESCRIPTION
### Description

* CCloudify Tumbling Windows

Note there is a warning now in the code that I'm not sure if it's something needing addressed:

```
> Task :_includes:tutorials:tumbling-windows:kstreams:code:compileJava
Note: /Users/yeva/git/kafka-tutorials/_includes/tutorials/tumbling-windows/kstreams/code/src/main/java/io/confluent/developer/TumblingWindow.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :_includes:tutorials:tumbling-windows:kstreams:code:compileTestJava
Note: /Users/yeva/git/kafka-tutorials/_includes/tutorials/tumbling-windows/kstreams/code/src/test/java/io/confluent/developer/TumblingWindowTest.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```

I added this into the build:

```
  tasks.withType(JavaCompile) {
      options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
  }
```

and it shows below.  However, adding `Map<String,String>` does not fix it.  Looking for advice whether code should be left as-is or suggestions on how to address. 

```
> Task :_includes:tutorials:tumbling-windows:kstreams:code:compileJava FAILED
/Users/yeva/git/kafka-tutorials/_includes/tutorials/tumbling-windows/kstreams/code/src/main/java/io/confluent/developer/TumblingWindow.java:84: warning: [unchecked] unchecked conversion
        final Map<String, String> serdeConfig = (Map)allProps;
                                                ^
  required: Map<String,String>
  found:    Map
```

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/ccloud-tumbling-windows/create-tumbling-windows/confluent.html
