### PR TITLE
MINOR:Revert gradle version flag

### DIFF
--- a/_includes/tutorials/serialization/kstreams/code/tutorial-steps/dev/gradle-wrapper.sh
+++ b/_includes/tutorials/serialization/kstreams/code/tutorial-steps/dev/gradle-wrapper.sh
@@ -1,1 +1,1 @@
-gradle wrapper  --gradle-version 6.7.1 --distribution-type all
+gradle wrapper 


### PR DESCRIPTION
### Description

Revert this fix to remove the version flag from the serialization KT `gradle-wrapper.sh` script
<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
