### PR TITLE
MINOR: Remove jcenter and use mavenCentral

### DIFF
--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
@@ -20,7 +20,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 version = "0.0.1"
 
 repositories {
-    jcenter()
+    mavenCentral()
 
     maven {
         url "https://packages.confluent.io/maven"

--- a/_includes/tutorials/produce-consume-lang/scala/code/settings.gradle
+++ b/_includes/tutorials/produce-consume-lang/scala/code/settings.gradle
@@ -1,13 +1,3 @@
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        jcenter()
-        maven {
-            name "JCenter Gradle Plugins"
-            url  "https://dl.bintray.com/gradle/gradle-plugins"
-        }
-    }
-}
 
 rootProject.name = 'produce-consume-scala'
 

--- a/_includes/tutorials/window-final-result/kstreams/code/settings.gradle
+++ b/_includes/tutorials/window-final-result/kstreams/code/settings.gradle
@@ -1,12 +1,2 @@
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        jcenter()
-        maven {
-            name "JCenter Gradle Plugins"
-            url  "https://dl.bintray.com/gradle/gradle-plugins"
-        }
-    }
-}
 
 rootProject.name = 'window-final-result'


### PR DESCRIPTION
### Description

Found one tutorial that still references `jcenter`.

@ybyzek your call to merge for this release or not.
### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
