### PR TITLE
#808: edit icon goes straight to KT subfolder

### DIFF
--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -39,7 +39,7 @@
 
   <section class="section">
     <div class="container">
-      <a href="{{ site.github_url }}/tree/master/_includes/tutorials/{{ page.static_data }}/{{ page.stack }}/code" class="btn-edit"><img src="{{ "/assets/img/icon-edit.svg" | relative_url }}" alt="Edit this page" /></a>
+      <a href="{{ site.github_url }}/tree/master/_includes/tutorials/{{ page.static_data }}" class="btn-edit"><img src="{{ "/assets/img/icon-edit.svg" | relative_url }}" alt="Edit this page" /></a>
       {% unless page.help_wanted %}
         <div class="example">
           <h3 class="title">Example use case:</h3>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -39,7 +39,7 @@
 
   <section class="section">
     <div class="container">
-      <a href="{{ site.github_url }}" class="btn-edit"><img src="{{ "/assets/img/icon-edit.svg" | relative_url }}" alt="Edit this page" /></a>
+      <a href="{{ site.github_url }}/tree/master/_includes/tutorials/{{ page.static_data }}/{{ page.stack }}/code" class="btn-edit"><img src="{{ "/assets/img/icon-edit.svg" | relative_url }}" alt="Edit this page" /></a>
       {% unless page.help_wanted %}
         <div class="example">
           <h3 class="title">Example use case:</h3>


### PR DESCRIPTION
### Description

https://github.com/confluentinc/kafka-tutorials/issues/808

Click on the edit icon under each KT.  The link *could* go straight to `[type]/code/` but then for Confluent tutorials that have shared code, it doesn't work well.

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/GH-808

