### PR TITLE
CCloudify aggregate counts

### DIFF
--- a/_data/harnesses/aggregating-count/confluent.yml
+++ b/_data/harnesses/aggregating-count/confluent.yml
@@ -1,0 +1,175 @@
+answer:
+  steps:
+    - title:
+      content:
+        - action: skip
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/answer/count-method.adoc
+
+dev:
+  steps:
+    - title: Initialize the project
+      content:
+        - action: execute
+          file: tutorial-steps/dev/init.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/init.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/make-configuration-dir.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/make-config-dir.adoc
+
+    - title: Sign up for Confluent Cloud and provision resources
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-setup-self.adoc
+
+    - title: Create a properties file with Confluent Cloud information
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/config-create.adoc
+
+    - title: Download and setup the Confluent Cloud CLI
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/get-ccloud.adoc
+
+    - title: Configure the project
+      content:
+        - action: make_file
+          file: build.gradle
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/make-build-file.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/gradle-wrapper.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/make-gradle-wrapper.adoc
+
+        - action: make_file
+          file: configuration/dev.properties
+          render:
+            file: tutorials/aggregating-count/confluent/markup/dev/make-config-file.adoc
+
+    - title: Update the properties file with Confluent Cloud information
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/append-ccloud-config.adoc
+
+    - title: Create a schema for the events
+      content:
+        - action: execute
+          file: tutorial-steps/dev/make-avro-dir.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/make-avro-dir.adoc
+
+        - action: make_file
+          file: src/main/avro/ticket-sale.avsc
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/make-ticket-sale-schema.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/build-project.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/build-project.adoc
+
+    - title: Create the Kafka Streams topology
+      content:
+        - action: execute
+          file: tutorial-steps/dev/make-src-dir.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/make-src-dir.adoc
+
+        - action: make_file
+          file: src/main/java/io/confluent/developer/AggregatingSum.java
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/make-topology.adoc
+
+    - title: Compile and run the Kafka Streams program
+      content:
+        - action: execute
+          file: tutorial-steps/dev/build-uberjar.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/build-uberjar.adoc
+
+        - action: execute_async
+          file: tutorial-steps/dev/run-dev-app.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/dev/run-dev-app.adoc
+
+    - title: Produce events to the input topic
+      content:
+        - action: skip
+          render:
+            file: tutorials/aggregating-count/confluent/markup/dev/ccloud-run-produce.adoc
+
+    - title: Consume aggregated count from the output topic
+      content:
+        - action: skip
+          render:
+            file: tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
+
+test:
+  steps:
+    - title: Create a test configuration file
+      content:
+        - action: make_file
+          file: configuration/test.properties
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/test/make-test-file.adoc
+
+    - title: Write a test
+      content:
+        - action: execute
+          file: tutorial-steps/test/make-test-dir.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/test/make-test-dir.adoc
+
+        - action: make_file
+          file: src/test/java/io/confluent/developer/AggregatingSumTest.java
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/test/make-test.adoc
+
+    - title: Invoke the tests
+      content:
+        - action: execute
+          file: tutorial-steps/test/invoke-tests.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/test/invoke-tests.adoc
+
+    - title: Teardown Confluent Cloud resources
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-destroy.adoc
+prod:
+  steps:
+    - title: Create a production configuration file
+      content:
+        - action: make_file
+          file: configuration/prod.properties
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/prod/make-prod-file.adoc
+
+    - title: Build a Docker image
+      content:
+        - action: execute
+          file: tutorial-steps/prod/build-image.sh
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/prod/build-image.adoc
+
+    - title: Launch the container
+      content:
+        - action: skip
+          render:
+            file: tutorials/aggregating-count/kstreams/markup/prod/launch-container.adoc
+
+        - action: execute
+          file: tutorial-steps/dev/clean-up.sh
+          render:
+            skip: true

--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -139,6 +139,7 @@ aggregating-count:
   status:
     ksql: enabled
     kstreams: enabled
+    confluent: enabled
 
 aggregating-minmax:
   title: "How to find the min/max in a stream of events"

--- a/_includes/shared/markup/ccloud/ccloud-sr-produce.adoc
+++ b/_includes/shared/markup/ccloud/ccloud-sr-produce.adoc
@@ -1,0 +1,9 @@
+You will be prompted for the Confluent Cloud Schema Registry credentials as shown below, which you can find in the `configuration/ccloud.properties` configuration file.
+Look for the configuration parameter `basic.auth.user.info`, whereby the ":" is the delimiter between the key and secret.
+
+```
+Enter your Schema Registry API key:
+Enter your Schema Registry API secret:
+```
+
+When the console producer starts, it will log some messages and hang, waiting for your input. Type in one line at a time and press enter to send it. Each line represents an event. To send all of the events below, paste the following into the prompt and press enter:

--- a/_includes/tutorials/aggregating-count/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/aggregating-count/confluent/code/configuration/dev.properties
@@ -1,0 +1,9 @@
+application.id=aggregating-count-app
+
+input.topic.name=movie-ticket-sales
+input.topic.partitions=6
+input.topic.replication.factor=3
+
+output.topic.name=movie-tickets-sold
+output.topic.partitions=6
+output.topic.replication.factor=3

--- a/_includes/tutorials/aggregating-count/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/aggregating-count/confluent/code/configuration/dev.properties
@@ -1,5 +1,3 @@
-application.id=aggregating-count-app
-
 input.topic.name=movie-ticket-sales
 input.topic.partitions=6
 input.topic.replication.factor=3
@@ -7,3 +5,6 @@ input.topic.replication.factor=3
 output.topic.name=movie-tickets-sold
 output.topic.partitions=6
 output.topic.replication.factor=3
+
+application.id=aggregating-count-app
+

--- a/_includes/tutorials/aggregating-count/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
+++ b/_includes/tutorials/aggregating-count/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
@@ -1,0 +1,5 @@
+ccloud kafka topic produce movie-ticket-sales \
+  --parse-key \
+  --delimiter ":" \
+  --value-format avro \
+  --schema src/main/avro/ticket-sale.avsc

--- a/_includes/tutorials/aggregating-count/confluent/code/tutorial-steps/dev/input-events.json
+++ b/_includes/tutorials/aggregating-count/confluent/code/tutorial-steps/dev/input-events.json
@@ -1,0 +1,9 @@
+"Die Hard":{"title":"Die Hard","sale_ts":"2019-07-18T10:00:00Z","ticket_total_value":12}
+"Die Hard":{"title":"Die Hard","sale_ts":"2019-07-18T10:01:00Z","ticket_total_value":12}
+"The Godfather":{"title":"The Godfather","sale_ts":"2019-07-18T10:01:31Z","ticket_total_value":12}
+"Die Hard":{"title":"Die Hard","sale_ts":"2019-07-18T10:01:36Z","ticket_total_value":24}
+"The Godfather":{"title":"The Godfather","sale_ts":"2019-07-18T10:02:00Z","ticket_total_value":18}
+"The Big Lebowski":{"title":"The Big Lebowski","sale_ts":"2019-07-18T11:03:21Z","ticket_total_value":12}
+"The Big Lebowski":{"title":"The Big Lebowski","sale_ts":"2019-07-18T11:03:50Z","ticket_total_value":12}
+"The Godfather":{"title":"The Godfather","sale_ts":"2019-07-18T11:40:00Z","ticket_total_value":36}
+"The Godfather":{"title":"The Godfather","sale_ts":"2019-07-18T11:40:09Z","ticket_total_value":18}

--- a/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,0 +1,15 @@
+Run the following command to start a Confluent Cloud CLI consumer to view consume the events that have been filtered by your application:
+
+```
+ccloud kafka topic consume movie-tickets-sold -b --print-key
+```
+
+After the consumer starts, you should see the following messages. Note that for every key (movie), a sequence of output records (count) is emitted. Each record represents an update to the count, which is sent on every movie event specifically because caching is disabled in the code with `StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG` set to `0`. Read more on `https://docs.confluent.io/current/streams/developer-guide/memory-mgmt.html#record-caches-in-the-dsl[Record caches in the DSL]`.
+
+The consumer prompt will hang, waiting for more events to arrive. To continue studying the example, send more events through the input terminal prompt. Otherwise, you can `Control-C` to exit the process.
+
++++++
+<pre class="snippet"><code class="json">{% include_raw tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/outputs/actual-output-events.json %}</code></pre>
++++++
+
+Enter `Ctrl+C` to exit.

--- a/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-produce.adoc
+++ b/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-produce.adoc
@@ -1,0 +1,21 @@
+In a new terminal, run:
+
++++++
+<pre class="snippet"><code class="bash">{% include_raw tutorials/aggregating-count/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh %}</code></pre>
++++++
+
+You will be prompted for the Confluent Cloud Schema Registry credentials as shown below, which you can find in the `configuration/ccloud.properties` configuration file.
+Look for the configuration parameter `basic.auth.user.info`, whereby the ":" is the delimiter between the key and secret.
+
+```
+Enter your Schema Registry API key:
+Enter your Schema Registry API secret:
+```
+
+When the console producer starts, it will log some messages and hang, waiting for your input. Type in one line at a time and press enter to send it. Each line represents an event. To send all of the events below, paste the following into the prompt and press enter:
+
++++++
+<pre class="snippet"><code class="json">{% include_raw tutorials/aggregating-count/confluent/code/tutorial-steps/dev/input-events.json %}</code></pre>
++++++
+
+Enter `Ctrl+C` to exit.

--- a/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-produce.adoc
+++ b/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-produce.adoc
@@ -4,15 +4,7 @@ In a new terminal, run:
 <pre class="snippet"><code class="bash">{% include_raw tutorials/aggregating-count/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh %}</code></pre>
 +++++
 
-You will be prompted for the Confluent Cloud Schema Registry credentials as shown below, which you can find in the `configuration/ccloud.properties` configuration file.
-Look for the configuration parameter `basic.auth.user.info`, whereby the ":" is the delimiter between the key and secret.
-
-```
-Enter your Schema Registry API key:
-Enter your Schema Registry API secret:
-```
-
-When the console producer starts, it will log some messages and hang, waiting for your input. Type in one line at a time and press enter to send it. Each line represents an event. To send all of the events below, paste the following into the prompt and press enter:
+include::_includes/shared/markup/ccloud/ccloud-sr-produce.adoc[]
 
 +++++
 <pre class="snippet"><code class="json">{% include_raw tutorials/aggregating-count/confluent/code/tutorial-steps/dev/input-events.json %}</code></pre>

--- a/_includes/tutorials/aggregating-count/confluent/markup/dev/make-config-file.adoc
+++ b/_includes/tutorials/aggregating-count/confluent/markup/dev/make-config-file.adoc
@@ -1,0 +1,5 @@
+Then create a development configuration file at `configuration/dev.properties`:
+
++++++
+<pre class="snippet"><code class="shell">{% include_raw tutorials/aggregating-count/confluent/code/configuration/dev.properties %}</code></pre>
++++++

--- a/_includes/tutorials/aggregating-count/kstreams/code/src/main/java/io/confluent/developer/AggregatingCount.java
+++ b/_includes/tutorials/aggregating-count/kstreams/code/src/main/java/io/confluent/developer/AggregatingCount.java
@@ -13,6 +13,7 @@ import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.Produced;
 
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,39 +23,26 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 
 import io.confluent.developer.avro.TicketSale;
+import io.confluent.common.utils.TestUtils;
 import io.confluent.kafka.streams.serdes.avro.SpecificAvroSerde;
 
 import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
 
 public class AggregatingCount {
 
-  public Properties buildStreamsProperties(Properties envProps) {
-    Properties props = new Properties();
-
-    props.put(StreamsConfig.APPLICATION_ID_CONFIG, envProps.getProperty("application.id"));
-    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, envProps.getProperty("bootstrap.servers"));
-    props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-    props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-    props.put(SCHEMA_REGISTRY_URL_CONFIG, envProps.getProperty("schema.registry.url"));
-    props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
-
-    return props;
-  }
-
-  private SpecificAvroSerde<TicketSale> ticketSaleSerde(final Properties envProps) {
+  private SpecificAvroSerde<TicketSale> ticketSaleSerde(final Properties allProps) {
     final SpecificAvroSerde<TicketSale> serde = new SpecificAvroSerde<>();
-    Map<String, String> config = new HashMap<>();
-    config.put(SCHEMA_REGISTRY_URL_CONFIG, envProps.getProperty("schema.registry.url"));
+    Map<String, String> config = (Map)allProps;
     serde.configure(config, false);
     return serde;
   }
 
-  public Topology buildTopology(Properties envProps,
+  public Topology buildTopology(Properties allProps,
                                 final SpecificAvroSerde<TicketSale> ticketSaleSerde) {
     final StreamsBuilder builder = new StreamsBuilder();
 
-    final String inputTopic = envProps.getProperty("input.topic.name");
-    final String outputTopic = envProps.getProperty("output.topic.name");
+    final String inputTopic = allProps.getProperty("input.topic.name");
+    final String outputTopic = allProps.getProperty("output.topic.name");
 
     builder.stream(inputTopic, Consumed.with(Serdes.String(), ticketSaleSerde))
         // Set key to title and value to ticket value
@@ -64,37 +52,35 @@ public class AggregatingCount {
         // Apply COUNT method
         .count()
         // Write to stream specified by outputTopic
-        .toStream().to(outputTopic, Produced.with(Serdes.String(), Serdes.Long()));
+        .toStream().mapValues(v -> v.toString()).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
 
     return builder.build();
   }
 
-  public void createTopics(Properties envProps) {
-    Map<String, Object> config = new HashMap<>();
-    config.put("bootstrap.servers", envProps.getProperty("bootstrap.servers"));
-    AdminClient client = AdminClient.create(config);
+  public void createTopics(Properties allProps) {
+    AdminClient client = AdminClient.create(allProps);
 
     List<NewTopic> topics = new ArrayList<>();
     topics.add(new NewTopic(
-        envProps.getProperty("input.topic.name"),
-        Integer.parseInt(envProps.getProperty("input.topic.partitions")),
-        Short.parseShort(envProps.getProperty("input.topic.replication.factor"))));
+        allProps.getProperty("input.topic.name"),
+        Integer.parseInt(allProps.getProperty("input.topic.partitions")),
+        Short.parseShort(allProps.getProperty("input.topic.replication.factor"))));
     topics.add(new NewTopic(
-        envProps.getProperty("output.topic.name"),
-        Integer.parseInt(envProps.getProperty("output.topic.partitions")),
-        Short.parseShort(envProps.getProperty("output.topic.replication.factor"))));
+        allProps.getProperty("output.topic.name"),
+        Integer.parseInt(allProps.getProperty("output.topic.partitions")),
+        Short.parseShort(allProps.getProperty("output.topic.replication.factor"))));
 
     client.createTopics(topics);
     client.close();
   }
 
   public Properties loadEnvProperties(String fileName) throws IOException {
-    Properties envProps = new Properties();
+    Properties allProps = new Properties();
     FileInputStream input = new FileInputStream(fileName);
-    envProps.load(input);
+    allProps.load(input);
     input.close();
 
-    return envProps;
+    return allProps;
   }
 
   public static void main(String[] args) throws IOException {
@@ -107,13 +93,18 @@ public class AggregatingCount {
   }
 
   private void runRecipe(final String configPath) throws IOException {
-    Properties envProps = this.loadEnvProperties(configPath);
-    Properties streamProps = this.buildStreamsProperties(envProps);
+    final Properties allProps = new Properties();
+    try (InputStream inputStream = new FileInputStream(configPath)) {
+      allProps.load(inputStream);
+    }
+    allProps.put(StreamsConfig.APPLICATION_ID_CONFIG, allProps.getProperty("application.id"));
+    allProps.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+    allProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
 
-    Topology topology = this.buildTopology(envProps, this.ticketSaleSerde(envProps));
-    this.createTopics(envProps);
+    Topology topology = this.buildTopology(allProps, this.ticketSaleSerde(allProps));
+    this.createTopics(allProps);
 
-    final KafkaStreams streams = new KafkaStreams(topology, streamProps);
+    final KafkaStreams streams = new KafkaStreams(topology, allProps);
     final CountDownLatch latch = new CountDownLatch(1);
 
     // Attach shutdown handler to catch Control-C.

--- a/_includes/tutorials/aggregating-count/kstreams/code/src/test/java/io/confluent/developer/AggregatingCountTest.java
+++ b/_includes/tutorials/aggregating-count/kstreams/code/src/test/java/io/confluent/developer/AggregatingCountTest.java
@@ -29,10 +29,10 @@ public class AggregatingCountTest {
   private final static String TEST_CONFIG_FILE = "configuration/test.properties";
   private TopologyTestDriver testDriver;
 
-  private SpecificAvroSerde<TicketSale> makeSerializer(Properties envProps) {
+  private SpecificAvroSerde<TicketSale> makeSerializer(Properties allProps) {
     SpecificAvroSerde<TicketSale> serde = new SpecificAvroSerde<>();
     Map<String, String> config = new HashMap<>();
-    config.put("schema.registry.url", envProps.getProperty("schema.registry.url"));
+    config.put("schema.registry.url", allProps.getProperty("schema.registry.url"));
     serde.configure(config, false);
     return serde;
   }
@@ -40,16 +40,15 @@ public class AggregatingCountTest {
   @Test
   public void shouldCountTicketSales() throws IOException {
     AggregatingCount aggCount = new AggregatingCount();
-    Properties envProps = aggCount.loadEnvProperties(TEST_CONFIG_FILE);
-    Properties streamProps = aggCount.buildStreamsProperties(envProps);
+    Properties allProps = aggCount.loadEnvProperties(TEST_CONFIG_FILE);
 
-    String inputTopic = envProps.getProperty("input.topic.name");
-    String outputTopic = envProps.getProperty("output.topic.name");
+    String inputTopic = allProps.getProperty("input.topic.name");
+    String outputTopic = allProps.getProperty("output.topic.name");
 
-    final SpecificAvroSerde<TicketSale> ticketSaleSpecificAvroSerde = makeSerializer(envProps);
+    final SpecificAvroSerde<TicketSale> ticketSaleSpecificAvroSerde = makeSerializer(allProps);
 
-    Topology topology = aggCount.buildTopology(envProps, ticketSaleSpecificAvroSerde);
-    testDriver = new TopologyTestDriver(topology, streamProps);
+    Topology topology = aggCount.buildTopology(allProps, ticketSaleSpecificAvroSerde);
+    testDriver = new TopologyTestDriver(topology, allProps);
 
     Serializer<String> keySerializer = Serdes.String().serializer();
     Deserializer<String> keyDeserializer = Serdes.String().deserializer();
@@ -71,18 +70,18 @@ public class AggregatingCountTest {
         .createInputTopic(inputTopic, keySerializer, ticketSaleSpecificAvroSerde.serializer())
         .pipeValueList(input);
     
-    List<Long> expectedOutput = new ArrayList<Long>(Arrays.asList(1L, 2L, 1L, 3L, 2L, 1L, 2L, 3L, 4L));
+    List<String> expectedOutput = new ArrayList<String>(Arrays.asList("1", "2", "1", "3", "2", "1", "2", "3", "4"));
 
-    final List<KeyValue<String, Long>> keyValues = 
+    final List<KeyValue<String, String>> keyValues =
         testDriver
-            .createOutputTopic(outputTopic, keyDeserializer, Serdes.Long().deserializer())
+            .createOutputTopic(outputTopic, keyDeserializer, Serdes.String().deserializer())
             .readKeyValuesToList();
 
-    List<Long> actualOutput;
+    List<String> actualOutput;
     actualOutput = keyValues
         .stream()
         .filter(record -> record.value != null)
-        .map(record -> record.value)
+        .map(record -> record.value.toString())
         .collect(Collectors.toList());
     
 //    System.out.println(actualOutput);

--- a/_includes/tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/console-consumer.sh
@@ -1,1 +1,1 @@
-docker exec -it broker /usr/bin/kafka-console-consumer --topic movie-tickets-sold --bootstrap-server broker:9092 --from-beginning --property print.key=true --property value.deserializer=org.apache.kafka.common.serialization.LongDeserializer
+docker exec -it broker /usr/bin/kafka-console-consumer --topic movie-tickets-sold --bootstrap-server broker:9092 --from-beginning --property print.key=true

--- a/_includes/tutorials/dynamic-output-topic/confluent/markup/dev/run-producer.adoc
+++ b/_includes/tutorials/dynamic-output-topic/confluent/markup/dev/run-producer.adoc
@@ -1,5 +1,5 @@
 ////
-   Example content file for how to include a console produer(s) in the tutorial.
+   Example content file for how to include a console producer(s) in the tutorial.
    Usually you'll include a line referencing the script to run the console producer and also include some content
    describing how to input data as shown below.
 
@@ -14,16 +14,7 @@ In a new terminal, run:
 <pre class="snippet"><code class="shell">{% include_raw tutorials/dynamic-output-topic/confluent/code/tutorial-steps/dev/ccloud-producer.sh %}</code></pre>
 +++++
 
-You will be prompted for the Confluent Cloud Schema Registry credentials as shown below, which you can find in the `configuration/ccloud.properties` configuration file.
-Look for the configuration parameter `basic.auth.user.info`, whereby the ":" is the delimiter between the key and secret.
-
-```
-Enter your Schema Registry API key:
-Enter your Schema Registry API secret:
-```
-
-When the producer starts, it will log some messages and hang, waiting for your input. Each line represents input data for the Kafka Streams application.
-To send all of the events below, paste the following into the prompt and press enter:
+include::_includes/shared/markup/ccloud/ccloud-sr-produce.adoc[]
 
 +++++
 <pre class="snippet"><code class="json">{% include_raw tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/input.json %}</code></pre>

--- a/_includes/tutorials/tumbling-windows/confluent/markup/dev/run-producer.adoc
+++ b/_includes/tutorials/tumbling-windows/confluent/markup/dev/run-producer.adoc
@@ -6,15 +6,7 @@ Start the console producer with this command in a terminal window of its own:
 <pre class="snippet"><code class="shell">{% include_raw tutorials/tumbling-windows/confluent/code/tutorial-steps/dev/console-producer-ratings.sh %}</code></pre>
 +++++
 
-You will be prompted for the Confluent Cloud Schema Registry credentials as shown below, which you can find in the `configuration/ccloud.properties` configuration file.
-Look for the configuration parameter `basic.auth.user.info`, whereby the ":" is the delimiter between the key and secret.
-
-```
-Enter your Schema Registry API key:
-Enter your Schema Registry API secret:
-```
-
-When the producer starts up, copy and paste these lines into the terminal:
+include::_includes/shared/markup/ccloud/ccloud-sr-produce.adoc[]
 
 +++++
 <pre class="snippet"><code class="json">{% include_raw tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/ratings.json %}</code></pre>

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,6 +41,7 @@ rootDir.traverse(
 // <beginning> include projects 
 include '_includes:tutorials:aggregating-average:kstreams:code'
 include '_includes:tutorials:aggregating-count:kstreams:code'
+include '_includes:tutorials:aggregating-count:confluent:code'
 include '_includes:tutorials:aggregating-minmax:kstreams:code'
 include '_includes:tutorials:aggregating-sum:kstreams:code'
 include '_includes:tutorials:cogrouping-streams:kstreams:code'

--- a/tutorials/aggregating-count/confluent.html
+++ b/tutorials/aggregating-count/confluent.html
@@ -1,0 +1,6 @@
+---
+layout: tutorial
+permalink: /create-stateful-aggregation-count/confluent
+stack: confluent
+static_data: aggregating-count
+---


### PR DESCRIPTION
### Description

CCloudify aggregate count KT. 

"Long" as a value format is not supported with `ccloud kafka topic consume` so modifications were necessary to the tutorial code, tests, and original KT kstreams instructions. We now convert the "Long" value into a string. The change is pretty simple.

I have walked through the Confluent tutorial locally, and have verified that the kstreams tutorial passes tests locally and in semaphore. 

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/convert-stateful-agg-count/
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/convert-stateful-agg-count/create-stateful-aggregation-count/kstreams.html
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/convert-stateful-agg-count/create-stateful-aggregation-count/confluent.html

### New tutorial checklist

- [ ] Add a `Short Answer`
- [ ] Implement good test cases
- [ ] Validate hyperlinks
- [ ] Spell check (e.g. using `aspell`)
