### PR TITLE
MINOR: Add test for aggregation-count KStreams

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -157,6 +157,10 @@ blocks:
         - name: KSQL aggregation count tests
           commands:
             - make -C _includes/tutorials/aggregating-count/ksql/code tutorial
+        
+        - name: KStreams aggregation count tests
+          commands:
+            - make -C _includes/tutorials/aggregating-count/kstreams/code tutorial
 
         - name: KSQL aggregation MIN/MAX tests
           commands:

--- a/_data/harnesses/aggregating-count/kstreams.yml
+++ b/_data/harnesses/aggregating-count/kstreams.yml
@@ -81,7 +81,7 @@ dev:
             file: tutorials/aggregating-count/kstreams/markup/dev/make-src-dir.adoc
 
         - action: make_file
-          file: src/main/java/io/confluent/developer/AggregatingSum.java
+          file: src/main/java/io/confluent/developer/AggregatingCount.java
           render:
             file: tutorials/aggregating-count/kstreams/markup/dev/make-topology.adoc
 
@@ -136,7 +136,7 @@ test:
             file: tutorials/aggregating-count/kstreams/markup/test/make-test-dir.adoc
 
         - action: make_file
-          file: src/test/java/io/confluent/developer/AggregatingSumTest.java
+          file: src/test/java/io/confluent/developer/AggregatingCountTest.java
           render:
             file: tutorials/aggregating-count/kstreams/markup/test/make-test.adoc
 

--- a/_includes/tutorials/aggregating-count/kstreams/code/src/main/java/io/confluent/developer/AggregatingCount.java
+++ b/_includes/tutorials/aggregating-count/kstreams/code/src/main/java/io/confluent/developer/AggregatingCount.java
@@ -15,6 +15,7 @@ import org.apache.kafka.streams.kstream.Produced;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -111,7 +112,7 @@ public class AggregatingCount {
     Runtime.getRuntime().addShutdownHook(new Thread("streams-shutdown-hook") {
       @Override
       public void run() {
-        streams.close();
+        streams.close(Duration.ofSeconds(5));
         latch.countDown();
       }
     });


### PR DESCRIPTION
### Description

Adding test entry for the `kstreams` flavor of `aggregation-count` to `semaphore.yml`. 

This entry has been missing for some time.
<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

- [ ] Add a `Short Answer`
- [ ] Implement good test cases
- [ ] Validate hyperlinks
- [ ] Spell check (e.g. using `aspell`)
