### PR TITLE
Add replication.factor=3 in confluent tutorials

### DIFF
--- a/_includes/tutorials/aggregating-count/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/aggregating-count/confluent/code/configuration/dev.properties
@@ -7,4 +7,4 @@ output.topic.partitions=6
 output.topic.replication.factor=3
 
 application.id=aggregating-count-app
-
+replication.factor=3

--- a/_includes/tutorials/dynamic-output-topic/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/dynamic-output-topic/confluent/code/configuration/dev.properties
@@ -1,4 +1,5 @@
 application.id=dynamic-output-topic
+replication.factor=3
 
 input.topic.name=input
 input.topic.partitions=6

--- a/_includes/tutorials/finding-distinct/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/finding-distinct/confluent/code/configuration/dev.properties
@@ -1,3 +1,5 @@
+replication.factor=3
+
 input.topic.name=clicks
 input.topic.partitions=6
 input.topic.replication.factor=3

--- a/_includes/tutorials/streams-to-table/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/streams-to-table/confluent/code/configuration/dev.properties
@@ -1,4 +1,5 @@
 application.id=streams-to-table
+replication.factor=3
 
 input.topic.name=input-topic
 input.topic.partitions=6

--- a/_includes/tutorials/tumbling-windows/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/tumbling-windows/confluent/code/configuration/dev.properties
@@ -1,4 +1,5 @@
 application.id=tumbling-window-app
+replication.factor=3
 
 rating.topic.name=ratings
 rating.topic.partitions=6


### PR DESCRIPTION
### Description

Add replication.factor=3 in CCloudified tutorial property files.

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

- [ ] Add a `Short Answer`
- [ ] Implement good test cases
- [ ] Validate hyperlinks
- [ ] Spell check (e.g. using `aspell`)
