### PR TITLE
MINOR: Add wait for SR and max wait of 5 seconds for streams app to close

### DIFF
--- a/_includes/tutorials/joining-stream-table/kstreams/code/src/main/java/io/confluent/developer/JoinStreamToTable.java
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/src/main/java/io/confluent/developer/JoinStreamToTable.java
@@ -14,7 +14,6 @@ import org.apache.kafka.streams.kstream.Produced;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/_includes/tutorials/joining-stream-table/kstreams/code/src/main/java/io/confluent/developer/JoinStreamToTable.java
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/src/main/java/io/confluent/developer/JoinStreamToTable.java
@@ -14,6 +14,7 @@ import org.apache.kafka.streams.kstream.Produced;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/_includes/tutorials/joining-stream-table/kstreams/code/tutorial-steps/dev/wait-for-containers.sh
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/tutorial-steps/dev/wait-for-containers.sh
@@ -12,3 +12,14 @@ while [[ $? != 0 ]]; do
     sleep 5
     readiness_probe
 done
+
+# Wait for Schema Registry to become available
+while : 
+  do curl_status=$(curl -s -o /dev/null -w %{http_code} http://localhost:8081)
+  echo -e $(date) " Schema Registry HTTP state: " $curl_status " (waiting for 200)" 
+  if [ $curl_status -eq 200 ] 
+    then  break
+  fi
+  sleep 5 
+done
+


### PR DESCRIPTION
### Description

Noticed this the Kafka Streams `streams-table join` tutorial test failed in one of our PR builds
```
org.apache.kafka.common.errors.SerializationException: Error serializing Avro message01:30
Caused by: java.net.ConnectException: Connection refused (Connection refused)01:30
	at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)01:30
	at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:399)01:30
	at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:242)01:30
	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:224)01:30
	at java.base/java.net.Socket.connect(Socket.java:609)01:30
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:177)01:30
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:474)
```
I believe this is a timing error as SR is not up and ready for serving requests.  This PR adds a wait for the test-harness to only proceed once SR is ready. 


### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

- [ ] Add a `Short Answer`
- [ ] Implement good test cases
- [ ] Validate hyperlinks
- [ ] Spell check (e.g. using `aspell`)
