### PR TITLE
#819: More vague directions for generating client configuration

### DIFF
--- a/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
+++ b/_includes/shared/markup/ccloud/ccloud-setup-self.adoc
@@ -3,7 +3,7 @@ Then provision your resources:
 
 1. After you log in to Confluent Cloud, click on `Add cloud environment` and name the environment `learn-kafka`. Using a new environment keeps your learning resources separate from your other Confluent Cloud resources.
 
-2. From the `Billing & payment` section, apply the promo code `CC100KTS` to receive an additional $100 free usage on Confluent Cloud (https://www.confluent.io/confluent-cloud-promo-disclaimer[details]).
+2. From the `Billing & payment` section in the Menu, apply the promo code `CC100KTS` to receive an additional $100 free usage on Confluent Cloud (https://www.confluent.io/confluent-cloud-promo-disclaimer[details]).
 
 3. Click on `LEARN` and follow the instructions to launch a Kafka cluster and to enable Schema Registry.
 

--- a/_includes/shared/markup/ccloud/config-create.adoc
+++ b/_includes/shared/markup/ccloud/config-create.adoc
@@ -1,12 +1,6 @@
-From the Confluent Cloud UI, navigate to your Kafka cluster and click on ``Clients``.
-Create credentials for the Kafka cluster and Schema Registry:
+From the Confluent Cloud UI, navigate to your Kafka cluster and click on ``Clients`` and then select ``Java``.
 
-- ``Create Kafka cluster API key & secret``
-
-- ``Create Schema Registry API key & secret``
-
-Select ``Java`` as the client.
-Confluent Cloud will show a configuration similar to below, but with your credentials populated (make sure ``show API keys`` is checked).
+Create new credentials for your Kafka cluster and Schema Registry, and then Confluent Cloud will show a configuration similar to below with your new credentials automatically populated (make sure ``show API keys`` is checked).
 Copy and paste it into a `configuration/ccloud.properties` file on your machine.
 
 +++++


### PR DESCRIPTION
### Description

https://github.com/confluentinc/kafka-tutorials/issues/819

- Slightly more vague, but still has dependency on the new client flow
- Note: https://confluentinc.atlassian.net/browse/CPG-1078

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/GH-819/creating-first-apache-kafka-producer-application/confluent.html#create-a-properties-file-with-confluent-cloud-information


