### PR TITLE
Modify help_wanted html logic

### DIFF
--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -214,10 +214,12 @@
   <div class="tutorial-markup">
     {% if page.help_wanted %}
     {% include contribute-tutorial.html %}
-    {% else if page.help_wanted_lang %}
-    {% include contribute-tutorial-lang.html %}
     {% else %}
-    {% include tutorial-content.html %}
+      {% if page.help_wanted_lang %}
+      {% include contribute-tutorial-lang.html %}
+      {% else %}
+      {% include tutorial-content.html %}
+      {% endif %}
     {% endif %}
   </div>
 


### PR DESCRIPTION
### Description
Found that tutorial content wasn't loading but was showing "help_wanted_lang" HTML instead, regardless of "help_wanted_lang" being set to false or not present. I modified the logic that presents the HTML to allow it to present the tutorial content.

[Staged latest master](http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/master/
), all tutorials show the help wanted HTML rather than there content ([example](http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/master/error-handling/kstreams.html)). The same tutorial on this branch which modified logic renders correctly ([example](http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/fix-help-lang/error-handling/kstreams.html)).

Verified that this branch still will display the "help_wanted_lang" page if "help_wanted_lang" is set to `true` ([example](http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/fix-help-lang/produce-consume-lang/go.html)).

### Staging Docs
shows help wanted lang:
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/fix-help-lang/produce-consume-lang/go.html
shows help wanted:
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/fix-help-lang/filter-a-stream-of-events/kafka.html
shows tutorial content:
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/fix-help-lang/error-handling/kstreams.html

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` -->
<!-- - [ ] Implement good test cases -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
