### PR TITLE
Add font awesome script to tutorial html

### DIFF
--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -230,5 +230,6 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/languages/scala.min.js"></script>
   <script src="{{ "/assets/js/tutorial.js" | relative_url }}"></script>
+  <script src="https://use.fontawesome.com/releases/v5.9.0/js/all.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Description

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->
Raised a PR - [https://github.com/confluentinc/kafka-tutorials/pull/913](url) to update the class names for font awesome but i missed adding the script for the tutorial html page. 

this PR will make it so both the home page and tutorial pages render the icons
### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` -->
<!-- - [ ] Implement good test cases -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
