### PR TITLE
Add images for matching patterns

### DIFF
--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -30,6 +30,7 @@ splitting:
   canonical: confluent
   slug: "/split-a-stream-of-events-into-substreams"
   question: "How do I split events in a Kafka topic so that the events are placed into subtopics?"
+  image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-router.svg
   introduction: "Suppose that you have a Kafka topic representing appearances of an actor or actress in a film, with each event denoting the genre. In this tutorial, we'll write a program that splits the stream into substreams based on the genre. We'll have a topic for drama films, a topic for fantasy films, and a topic for everything else."
   status:
     ksql: enabled
@@ -43,6 +44,7 @@ merging:
   canonical: confluent
   slug: "/merge-many-streams-into-one-stream"
   question: "If I have many Kafka topics with events, how do I merge them all into a single topic?"
+  image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-stream-merger.svg
   introduction: "Suppose that you have a set of Kafka topics representing songs being played of a particular genre. You might have a topic for rock songs, another for classical songs, and so forth. In this tutorial, we'll write a program that merges all of the song play events into a single topic."
   status:
     ksql: enabled
@@ -56,6 +58,7 @@ joining-stream-table:
   canonical: confluent
   slug: "/join-a-stream-to-a-table"
   question: "If I have events in a Kafka topic and a table of reference data (aka a lookup table), how can I join each event in the stream to a piece of data in the table based on a common key?"
+  image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-joiner.svg
   introduction: "Suppose you have a set of movies that have been released and a stream of ratings from movie-goers about how entertaining they are. In this tutorial, we'll write a program that joins each rating with content about the movie."
   status:
     ksql: enabled
@@ -280,6 +283,7 @@ dynamic-output-topic:
   canonical: confluent
   slug: "/dynamic-output-topic"
   question: "How can I dynamically route records to different Kafka topics, like a \"topic exchange\"?"
+  image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-router.svg
   introduction: "Consider a situation where you want to direct output of different records to different topics, like a \"topic exchange\". In this tutorial, you'll learn how to instruct Kafka Streams to choose the output topic at runtime, based on information in each record's header, key, or value."
   status:
     ksql: disabled

--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -31,7 +31,7 @@ splitting:
   slug: "/split-a-stream-of-events-into-substreams"
   question: "How do I split events in a Kafka topic so that the events are placed into subtopics?"
   image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-router.svg
-  introduction: "Suppose that you have a Kafka topic representing appearances of an actor or actress in a film, with each event denoting the genre. In this tutorial, we'll write a program that splits the stream into substreams based on the genre. We'll have a topic for drama films, a topic for fantasy films, and a topic for everything else."
+  introduction: "Suppose that you have a Kafka topic representing appearances of an actor or actress in a film, with each event denoting the genre. In this tutorial, we'll write a program that splits the stream into substreams based on the genre. We'll have a topic for drama films, a topic for fantasy films, and a topic for everything else. Related pattern: <a href=\"https://developer.confluent.io/patterns/event-processing/event-router\">Event Router</a>"
   status:
     ksql: enabled
     kstreams: enabled
@@ -45,7 +45,7 @@ merging:
   slug: "/merge-many-streams-into-one-stream"
   question: "If I have many Kafka topics with events, how do I merge them all into a single topic?"
   image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-stream-merger.svg
-  introduction: "Suppose that you have a set of Kafka topics representing songs being played of a particular genre. You might have a topic for rock songs, another for classical songs, and so forth. In this tutorial, we'll write a program that merges all of the song play events into a single topic."
+  introduction: "Suppose that you have a set of Kafka topics representing songs being played of a particular genre. You might have a topic for rock songs, another for classical songs, and so forth. In this tutorial, we'll write a program that merges all of the song play events into a single topic. Related pattern: <a href=\"https://developer.confluent.io/patterns/stream-processing/event-stream-merger\">Event Stream Merger</a>"
   status:
     ksql: enabled
     kstreams: enabled
@@ -59,7 +59,7 @@ joining-stream-table:
   slug: "/join-a-stream-to-a-table"
   question: "If I have events in a Kafka topic and a table of reference data (aka a lookup table), how can I join each event in the stream to a piece of data in the table based on a common key?"
   image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-joiner.svg
-  introduction: "Suppose you have a table of movie information and a stream of ratings from movie-goers about how entertaining the movies are. In this tutorial, we'll write a program that joins each rating with content about the movie."
+  introduction: "Suppose you have a table of movie information and a stream of ratings from movie-goers about how entertaining the movies are. In this tutorial, we'll write a program that joins each rating with content about the movie.  Related pattern: <a href=\"https://developer.confluent.io/patterns/stream-processing/event-joiner\">Event Joiner</a>"
   status:
     ksql: enabled
     kstreams: enabled
@@ -284,7 +284,7 @@ dynamic-output-topic:
   slug: "/dynamic-output-topic"
   question: "How can I dynamically route records to different Kafka topics, like a \"topic exchange\"?"
   image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-router.svg
-  introduction: "Consider a situation where you want to direct output of different records to different topics, like a \"topic exchange\". In this tutorial, you'll learn how to instruct Kafka Streams to choose the output topic at runtime, based on information in each record's header, key, or value."
+  introduction: "Consider a situation where you want to direct output of different records to different topics, like a \"topic exchange\". In this tutorial, you'll learn how to instruct Kafka Streams to choose the output topic at runtime, based on information in each record's header, key, or value. Related pattern: <a href=\"https://developer.confluent.io/patterns/event-processing/event-router\">Event Router</a>"
   status:
     ksql: disabled
     kstreams: enabled

--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -59,7 +59,7 @@ joining-stream-table:
   slug: "/join-a-stream-to-a-table"
   question: "If I have events in a Kafka topic and a table of reference data (aka a lookup table), how can I join each event in the stream to a piece of data in the table based on a common key?"
   image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-joiner.svg
-  introduction: "Suppose you have a table of movie information and a stream of ratings from movie-goers about how entertaining the movies are. In this tutorial, we'll write a program that joins each rating with content about the movie.  Related pattern: <a href=\"https://developer.confluent.io/patterns/stream-processing/event-joiner\">Event Joiner</a>"
+  introduction: "Suppose you have multiple data sources: one source is a table of movie information and one source generates a live stream of ratings from movie-goers about how entertaining the movies are. In this tutorial, we'll write a program that joins each rating with content about the movie, so that you can have a single stream with enriched data.  Related pattern: <a href=\"https://developer.confluent.io/patterns/stream-processing/event-joiner\">Event Joiner</a>"
   status:
     ksql: enabled
     kstreams: enabled

--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -59,7 +59,7 @@ joining-stream-table:
   slug: "/join-a-stream-to-a-table"
   question: "If I have events in a Kafka topic and a table of reference data (aka a lookup table), how can I join each event in the stream to a piece of data in the table based on a common key?"
   image: https://raw.githubusercontent.com/confluentinc/event-streaming-patterns/main/docs/img/event-joiner.svg
-  introduction: "Suppose you have a set of movies that have been released and a stream of ratings from movie-goers about how entertaining they are. In this tutorial, we'll write a program that joins each rating with content about the movie."
+  introduction: "Suppose you have a table of movie information and a stream of ratings from movie-goers about how entertaining the movies are. In this tutorial, we'll write a program that joins each rating with content about the movie."
   status:
     ksql: enabled
     kstreams: enabled

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -55,12 +55,10 @@
       {% unless page.help_wanted %}
         <div class="example">
           <h3 class="title">Example use case:</h3>
-          <table><tr>
-          <td><p class="text">{{ site.data.tutorials[page.static_data].introduction }}</p></td>
+          <p class="text">{{ site.data.tutorials[page.static_data].introduction }}</p>
           {% if site.data.tutorials[page.static_data].image %}
-          <td><figure class="image"><img src="{{ site.data.tutorials[page.static_data].image }}" /></figure></td>
+          <img src="{{ site.data.tutorials[page.static_data].image }}" />
           {% endif %}
-          </tr></table>
         </div>
       {% endunless %}
       <h3 class="title">Code example:</h3>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -56,6 +56,9 @@
         <div class="example">
           <h3 class="title">Example use case:</h3>
           <p class="text">{{ site.data.tutorials[page.static_data].introduction }}</p>
+          {% if site.data.tutorials[page.static_data].image %}
+          <p align="center"><img src="{{ site.data.tutorials[page.static_data].image }}" width=800></p>
+          {% endif %}
         </div>
       {% endunless %}
       <h3 class="title">Code example:</h3>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -56,9 +56,9 @@
         <div class="example">
           <h3 class="title">Example use case:</h3>
           <table><tr>
-          <td width=35%><p class="text">{{ site.data.tutorials[page.static_data].introduction }}</p></td>
+          <td><p class="text">{{ site.data.tutorials[page.static_data].introduction }}</p></td>
           {% if site.data.tutorials[page.static_data].image %}
-          <td><p align="center"><img src="{{ site.data.tutorials[page.static_data].image }}" width=600 /></p></td>
+          <td><figure class="image"><img src="{{ site.data.tutorials[page.static_data].image }}" /></figure></td>
           {% endif %}
           </tr></table>
         </div>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -57,7 +57,7 @@
           <h3 class="title">Example use case:</h3>
           <p class="text">{{ site.data.tutorials[page.static_data].introduction }}</p>
           {% if site.data.tutorials[page.static_data].image %}
-          <p align="center"><img src="{{ site.data.tutorials[page.static_data].image }}" width=800></p>
+          <p align="left"><img src="{{ site.data.tutorials[page.static_data].image }}" width=800></p>
           {% endif %}
         </div>
       {% endunless %}

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -55,10 +55,12 @@
       {% unless page.help_wanted %}
         <div class="example">
           <h3 class="title">Example use case:</h3>
-          <p class="text">{{ site.data.tutorials[page.static_data].introduction }}</p>
+          <table><tr>
+          <td width=35%><p class="text">{{ site.data.tutorials[page.static_data].introduction }}</p></td>
           {% if site.data.tutorials[page.static_data].image %}
-          <p align="left"><img src="{{ site.data.tutorials[page.static_data].image }}" width=800></p>
+          <td><p align="center"><img src="{{ site.data.tutorials[page.static_data].image }}" width=600 /></p></td>
           {% endif %}
+          </tr></table>
         </div>
       {% endunless %}
       <h3 class="title">Code example:</h3>


### PR DESCRIPTION
### Description

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

Re-use images from the patterns, where it makes sense:

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/images/split-a-stream-of-events-into-substreams/confluent.html
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/images/merge-many-streams-into-one-stream/confluent.html
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/images/join-a-stream-to-a-table/confluent.html
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/images/dynamic-output-topic/confluent.html

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` -->
<!-- - [ ] Implement good test cases -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
