### PR TITLE
Reorder tutorials on cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,8 @@
             <li><a href="creating-first-apache-kafka-producer-application/confluent.html">Your first Kafka producer application</a></li>
             <li><a href="creating-first-apache-kafka-consumer-application/confluent.html">Your first Kafka consumer application</a></li>
             <li><a href="kafka-producer-callback-application/confluent.html">Callbacks</a></li>
-            <li><a href="produce-consume-lang/scala.html">Non-Java client applications</a></li>
             <li><a href="error-handling/confluent.html">Uncaught Exceptions</a></li>
+            <li><a href="produce-consume-lang/scala.html">Non-Java client applications</a></li>
           </ul>
         </div>
 
@@ -72,8 +72,8 @@
             <div>Kafka topics</div>
           </div>
           <ul>
-            <li><a href="change-topic-partitions-replicas/ksql.html">Update partitions and replicas</a></li>
             <li><a href="how-to-count-messages-on-a-kafka-topic/confluent.html">Count the number of messages</a></li>
+            <li><a href="change-topic-partitions-replicas/ksql.html">Update partitions and replicas</a></li>
           </ul>
         </div> 
       </div>
@@ -102,10 +102,10 @@
             <div>Manipulate Streams</div>
           </div>
           <ul>
+            <li><a href="kafka-streams-convert-to-ktable/confluent.html">Convert a KStream to a KTable</a></li>
             <li><a href="rekey-a-stream/ksql.html">Rekey a stream with a value</a></li>
             <li><a href="rekey-with-function/ksql.html">Rekey a stream with a function</a></li>
             <li><a href="naming-stateful-operations/kstreams.html">Name stateful operations</a></li>
-            <li><a href="kafka-streams-convert-to-ktable/confluent.html">Convert a KStream to a KTable</a></li>
             <li><a href="handling-deserialization-errors/ksql.html">Handle deserialization errors</a></li>
             <li><a href="changing-serialization-format/ksql.html">Convert serialization format</a></li>
             <li><a href="kafka-streams-schedule-operations/kstreams.html">Scheduling operations</a></li>
@@ -153,8 +153,8 @@
           </div>
           <ul>
             <li><a href="create-tumbling-windows/confluent.html">Tumbling windows</a></li>
-            <li><a href="create-hopping-windows/ksql.html">Hopping windows</a></li>
             <li><a href="create-session-windows/confluent.html">Session windows</a></li>
+            <li><a href="create-hopping-windows/ksql.html">Hopping windows</a></li>
             <li><a href="sliding-windows/kstreams.html">Sliding windows</a></li>
             <li><a href="window-final-result/kstreams.html">Emit a final result</a></li>
             <li><a href="anomaly-detection/ksql.html">Anomaly detection</a></li>
@@ -168,10 +168,10 @@
             <div>Connect data sources & sinks</div>
           </div>
           <ul>
-            <li><a href="connect-add-key-to-source/kstreams.html">Add a key to a stream from a JDBC source</a></li>
-            <li><a href="connect-sink-timestamp/ksql.html">Convert timezone before sending to a database</a></li>
             <li><a href="kafka-connect-datagen/confluent.html">Generate simple mock Kafka data</a></li>
             <li><a href="generate-streams-of-test-data/ksql.html">Generate complex mock Kafka data</a></li>
+            <li><a href="connect-add-key-to-source/kstreams.html">Add a key to a stream from a JDBC source</a></li>
+            <li><a href="connect-sink-timestamp/ksql.html">Convert timezone before sending to a database</a></li>
           </ul>
         </div>
        </div>
@@ -185,10 +185,10 @@
             <div>Access Fields</div>
           </div>
           <ul>
+            <li><a href="transform-a-stream-of-events/confluent.html">Transform a stream of events</a></li>
             <li><a href="working-with-json-different-structure/ksql.html">Heterogenous JSON</a></li>
             <li><a href="working-with-nested-json/ksql.html">Nested JSON</a></li>
             <li><a href="flatten-nested-data/ksql.html">Flatten deeply nested events</a></li>
-            <li><a href="transform-a-stream-of-events/confluent.html">Transform a stream of events</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
### Description

Better flow of tutorials on cards

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/reorder_cards
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` -->
<!-- - [ ] Implement good test cases -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
