### PR TITLE
Change step order for CCloud to be first

### DIFF
--- a/_data/harnesses/console-consumer-read-specific-offsets-partition/confluent.yml
+++ b/_data/harnesses/console-consumer-read-specific-offsets-partition/confluent.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Provision your Kafka cluster
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-setup-self.adoc
+
     - title: Initialize the project
       content:
         - action: execute
@@ -19,12 +25,6 @@ dev:
           file: tutorial-steps/dev/make-configuration-dir.sh
           render:
             file: tutorials/console-consumer-read-specific-offsets-partition/confluent/markup/dev/make-config-dir.adoc
-
-    - title: Provision your Kafka cluster
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/ccloud-setup-self.adoc
 
     - title: Write the cluster information into a local file
       content:

--- a/_data/harnesses/count-messages/confluent.yml
+++ b/_data/harnesses/count-messages/confluent.yml
@@ -8,18 +8,18 @@ answer:
 
 dev:
   steps:
+    - title: Provision your Kafka cluster
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-setup-self.adoc
+
     - title: Initialize the project
       content:
         - action: execute
           file: tutorial-steps/dev/01a-init.sh
           render:
             file: tutorials/count-messages/kafka/markup/dev/01a-init.adoc
-
-    - title: Provision your Kafka cluster
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/ccloud-setup-self.adoc
 
     - title: Write the cluster information into a local file
       content:

--- a/_data/harnesses/filtering/confluent.yml
+++ b/_data/harnesses/filtering/confluent.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Provision your Kafka cluster
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-setup-self.adoc
+
     - title: Initialize the project
       content:
         - action: execute
@@ -19,12 +25,6 @@ dev:
           file: tutorial-steps/dev/make-configuration-dir.sh
           render:
             file: tutorials/filtering/kstreams/markup/dev/make-config-dir.adoc
-
-    - title: Provision your Kafka cluster
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/ccloud-setup-self.adoc
 
     - title: Write the cluster information into a local file
       content:

--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Provision your Kafka cluster
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-setup-self.adoc
+
     - title: Initialize the project
       content:
         - action: execute
@@ -11,12 +17,6 @@ dev:
           file: tutorial-steps/dev/make-configuration-dir.sh
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/make-config-dir.adoc
-
-    - title: Provision your Kafka cluster
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/ccloud-setup-self.adoc
 
     - title: Write the cluster information into a local file
       content:

--- a/_data/harnesses/kafka-producer-application/confluent.yml
+++ b/_data/harnesses/kafka-producer-application/confluent.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Provision your Kafka cluster
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud-setup-self.adoc
+
     - title: Initialize the project
       content:
         - action: execute
@@ -11,12 +17,6 @@ dev:
           file: tutorial-steps/dev/make-configuration-dir.sh
           render:
             file: tutorials/kafka-producer-application/kafka/markup/dev/make-config-dir.adoc
-
-    - title: Provision your Kafka cluster
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/ccloud-setup-self.adoc
 
     - title: Write the cluster information into a local file
       content:

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/markup/dev/init.adoc
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/markup/dev/init.adoc
@@ -1,4 +1,4 @@
-To get started, make a new directory anywhere you'd like for this project:
+Make a local directory anywhere you'd like for this project:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/init.sh %}</code></pre>

--- a/_includes/tutorials/count-messages/kafka/markup/dev/01a-init.adoc
+++ b/_includes/tutorials/count-messages/kafka/markup/dev/01a-init.adoc
@@ -1,4 +1,4 @@
-To get started, make a new directory anywhere you'd like for this project:
+Make a local directory anywhere you'd like for this project:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/count-messages/ksql/code/tutorial-steps/dev/01a-init.sh %}</code></pre>

--- a/_includes/tutorials/filtering/kstreams/markup/dev/init.adoc
+++ b/_includes/tutorials/filtering/kstreams/markup/dev/init.adoc
@@ -1,4 +1,4 @@
-To get started, make a new directory anywhere you'd like for this project:
+Make a local directory anywhere you'd like for this project:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/filtering/kstreams/code/tutorial-steps/dev/init.sh %}</code></pre>

--- a/_includes/tutorials/kafka-consumer-application/kafka/markup/dev/init.adoc
+++ b/_includes/tutorials/kafka-consumer-application/kafka/markup/dev/init.adoc
@@ -1,4 +1,4 @@
-To get started, make a new directory anywhere you'd like for this project:
+Make a local directory anywhere you'd like for this project:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/init.sh %}</code></pre>

--- a/_includes/tutorials/kafka-producer-application/kafka/markup/dev/init.adoc
+++ b/_includes/tutorials/kafka-producer-application/kafka/markup/dev/init.adoc
@@ -1,4 +1,4 @@
-To get started, make a new directory anywhere you'd like for this project:
+Make a local directory anywhere you'd like for this project:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/init.sh %}</code></pre>


### PR DESCRIPTION
### Description

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/change_kt_order_ccloud
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` -->
<!-- - [ ] Implement good test cases -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
