### PR TITLE
feat: [UIF-1011] Add swiftype metatag for site of Kafka-Tutorials

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="{{ site.description }}">
+    <meta class="swiftype" name="site-id" data-type="integer" content="5" />
     <title>{{ site.title }}</title>
     <link rel="stylesheet" href="{{ "/assets/sass/fonts.css" | relative_url }}" />
     <link rel="stylesheet" href="{{ "/assets/sass/main.css" | relative_url }}" />
@@ -76,11 +77,11 @@
             <li><a href="how-to-count-messages-on-a-kafka-topic/confluent.html">Count the number of messages</a></li>
             <li><a href="change-topic-partitions-replicas/ksql.html">Update partitions and replicas</a></li>
           </ul>
-        </div> 
+        </div>
       </div>
 
       <!-- END cards -->
-      <div class="cards secondary-card-row"> 
+      <div class="cards secondary-card-row">
 
        <div class="card">
           <div class="title">
@@ -95,7 +96,7 @@
             <li><a href="finding-distinct-events/confluent.html">Find distinct events</a></li>
           </ul>
           <!--div id="show"><a class="button is-small is-fullwidth">More</a></div-->
-        </div> 
+        </div>
 
         <div class="card">
           <div class="title">


### PR DESCRIPTION
### Description
https://confluentinc.atlassian.net/browse/UIF-1011

In order to support more sophisticated, faceted search in docs.confluent.io, we are looking at adding some meta tags to a number of websites that are currently included in docs' swiftype search engine. This will allow search results to be targeted at specific sites (and languages).  

The following sites are involved:

Site | Id
-- | --
https://docs.confluent.io/ | 1
https://www.confluent.io/blog/ | 2
https://developer.confluent.io/ | 3
https://docs.ksqldb.io/en/latest/ | 4
https://kafka-tutorials.confluent.io/ | 5
https://api.telemetry.confluent.cloud/docs | 6

The change involved is minimal and would be to add the following meta tag into the main template file of each site:
`<meta class="swiftype" name="site-id" data-type="integer" content="1" />`

Please let me know if there is any issue that you foresee with this change or if you have any questions. 
  
Additional reading: https://swiftype.com/documentation/site-search/guides/schema-design#crawler

(Sorry for the noise in the commit history. Hotkeyed myself into a mistake and reverted it.) 

