### PR TITLE
Earlier CTA for non-CCloud tutorials

### DIFF
--- a/_includes/tutorials/aggregating-average/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-average/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/aggregating-average/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-average/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-average/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/aggregating-average/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-count/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-count/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/aggregating-count/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-count/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-count/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/aggregating-count/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-count/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-count/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-count/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-count/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-minmax/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-minmax/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/aggregating-minmax/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-minmax/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-minmax/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/aggregating-minmax/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-minmax/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-minmax/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-minmax/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-minmax/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-sum/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-sum/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/aggregating-sum/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-sum/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-sum/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/aggregating-sum/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-sum/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-sum/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/aggregating-sum/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/aggregating-sum/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/anomaly-detection/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/anomaly-detection/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/anomaly-detection/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/anomaly-detection/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/anomaly-detection/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/anomaly-detection/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/change-topic-partitions-replicas/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/change-topic-partitions-replicas/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/cogrouping-streams/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/cogrouping-streams/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/cogrouping-streams/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/cogrouping-streams/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/cogrouping-streams/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/cogrouping-streams/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/column-difference/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/column-difference/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/column-difference/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/column-difference/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/column-difference/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/column-difference/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/concatenation/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/concatenation/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/concatenation/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/concatenation/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/concatenation/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/concatenation/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/connect-add-key-to-source/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/connect-add-key-to-source/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/connect-add-key-to-source/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform. Make sure that you create this file in the same place as the `cities.sql` file that you created above.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/connect-add-key-to-source/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/connect-add-key-to-source/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/connect-add-key-to-source/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform. Make sure that you create this file in the same place as the `cities.sql` file that you created above.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/connect-add-key-to-source/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/connect-add-key-to-source/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/connect-add-key-to-source/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/connect-add-key-to-source/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/connect-add-key-to-source/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/connect-add-key-to-source/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/console-consumer-primitive-keys-values/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/console-consumer-primitive-keys-values/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/console-consumer-producer-avro/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/console-consumer-producer-avro/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/console-consumer-producer-basic/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/console-consumer-producer-basic/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/console-consumer-read-specific-offsets-partition/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]).
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/console-consumer-read-specific-offsets-partition/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/count-messages/kafka/markup/dev/02a-make-docker-compose.adoc
+++ b/_includes/tutorials/count-messages/kafka/markup/dev/02a-make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/count-messages/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/count-messages/kafka/markup/dev/02a-make-docker-compose.adoc
+++ b/_includes/tutorials/count-messages/kafka/markup/dev/02a-make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/count-messages/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/count-messages/ksql/markup/dev/02a-make-docker-compose.adoc
+++ b/_includes/tutorials/count-messages/ksql/markup/dev/02a-make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/count-messages/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/count-messages/ksql/markup/dev/02a-make-docker-compose.adoc
+++ b/_includes/tutorials/count-messages/ksql/markup/dev/02a-make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/count-messages/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/creating-first-apache-kafka-streams-application/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/creating-first-apache-kafka-streams-application/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/deserialization-errors/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/deserialization-errors/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/deserialization-errors/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/deserialization-errors/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/deserialization-errors/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/deserialization-errors/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/dynamic-output-topic/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/dynamic-output-topic/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/error-handling/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/error-handling/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/error-handling/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/error-handling/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/error-handling/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/error-handling/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/filtering/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/filtering/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/filtering/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/filtering/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/filtering/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/filtering/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/filtering/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/filtering/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/finding-distinct/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/finding-distinct/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/finding-distinct/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/finding-distinct/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/finding-distinct/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/finding-distinct/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/fk-joins/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/fk-joins/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/fk-joins/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/fk-joins/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/fk-joins/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/fk-joins/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/flatten-nested-data/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/flatten-nested-data/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/flatten-nested-data/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/flatten-nested-data/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/flatten-nested-data/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/flatten-nested-data/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/generate-test-data-streams/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/generate-test-data-streams/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform. Make sure that you create this file in the same place as the `cities.sql` file that you created above.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/generate-test-data-streams/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/generate-test-data-streams/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/generate-test-data-streams/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/generate-test-data-streams/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/generate-test-data-streams/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/generate-test-data-streams/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform. Make sure that you create this file in the same place as the `cities.sql` file that you created above.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/generate-test-data-streams/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/generate-test-data-streams/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/generate-test-data-streams/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Make sure that you create this file in the same place as the `cities.sql` file that you created above.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/generate-test-data-streams/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/geo-distance/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/geo-distance/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/geo-distance/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/geo-distance/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/geo-distance/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/geo-distance/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/hopping-windows/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/hopping-windows/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/hopping-windows/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/hopping-windows/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/hopping-windows/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/hopping-windows/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/joining-stream-stream/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/joining-stream-stream/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/joining-stream-stream/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/joining-stream-stream/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/joining-stream-stream/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/joining-stream-stream/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/joining-stream-table/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/joining-stream-table/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/joining-stream-table/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/joining-stream-table/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/joining-stream-table/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/joining-stream-table/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/joining-stream-table/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/joining-stream-table/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/joining-stream-table/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/joining-stream-table/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/joining-table-table/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/joining-table-table/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/joining-table-table/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/joining-table-table/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/joining-table-table/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/joining-table-table/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-connect-datagen/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-connect-datagen/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Note that it also is configured to build a local image.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Note that it also is configured to build a local image.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-connect-datagen/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-connect-datagen/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-connect-datagen/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform. Note that it also is configured to build a local image.
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]). Note that it also is configured to build a local image.
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-connect-datagen/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-consumer-application/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-consumer-application/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-consumer-application/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-consumer-application/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-consumer-application/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-consumer-application/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-producer-application-callback/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-producer-application-callback/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-producer-application/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-producer-application/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-producer-application/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-producer-application/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-producer-application/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-producer-application/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-streams-schedule-operations/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/kafka-streams-schedule-operations/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/ksql-heterogeneous-json/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/ksql-heterogeneous-json/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/ksql-heterogeneous-json/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/ksql-heterogeneous-json/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/ksql-heterogeneous-json/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/ksql-heterogeneous-json/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/ksql-nested-json/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/ksql-nested-json/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/ksql-nested-json/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/ksql-nested-json/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/ksql-nested-json/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/ksql-nested-json/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/masking-data/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/masking-data/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/masking-data/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/masking-data/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/masking-data/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/masking-data/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/merging/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/merging/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/merging/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/merging/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/merging/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/merging/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/merging/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/merging/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/merging/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/merging/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/message-ordering/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/message-ordering/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]) (this tutorial uses just ZooKeeper and the Kafka broker):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]) (this tutorial uses just ZooKeeper and the Kafka broker):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/message-ordering/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/message-ordering/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/message-ordering/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (this tutorial uses just ZooKeeper and the Kafka broker):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]) (this tutorial uses just ZooKeeper and the Kafka broker):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/message-ordering/kafka/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/multi-joins/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/multi-joins/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/multi-joins/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/multi-joins/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/multi-joins/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/multi-joins/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/naming-changelog-repartition-topics/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/naming-changelog-repartition-topics/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/produce-consume-lang/scala/markup/dev/1_1-make-docker-compose.adoc
+++ b/_includes/tutorials/produce-consume-lang/scala/markup/dev/1_1-make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="yaml">{%

--- a/_includes/tutorials/produce-consume-lang/scala/markup/dev/1_1-make-docker-compose.adoc
+++ b/_includes/tutorials/produce-consume-lang/scala/markup/dev/1_1-make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="yaml">{%

--- a/_includes/tutorials/rekeying-function/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/rekeying-function/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/rekeying-function/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/rekeying-function/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/rekeying-function/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/rekeying-function/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/rekeying/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/rekeying/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/rekeying/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/rekeying/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/rekeying/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/rekeying/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/schedule-ktable-ttl-aggregate/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/schedule-ktable-ttl-aggregate/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/schedule-ktable-ttl/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/schedule-ktable-ttl/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/serialization/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/serialization/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/serialization/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/serialization/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/serialization/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/serialization/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/serialization/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/serialization/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/serialization/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/serialization/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/serialization/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/serialization/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/session-windows/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/session-windows/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/session-windows/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/session-windows/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/session-windows/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/session-windows/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/session-windows/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/session-windows/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/session-windows/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/session-windows/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/session-windows/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/session-windows/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/sliding-windows/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/sliding-windows/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/sliding-windows/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/sliding-windows/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/sliding-windows/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/sliding-windows/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/splitting/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/splitting/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/splitting/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/splitting/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/splitting/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/splitting/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/splitting/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/splitting/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/splitting/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/splitting/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/streams-to-table/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/streams-to-table/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/streams-to-table/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/streams-to-table/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/streams-to-table/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/streams-to-table/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/time-concepts/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/time-concepts/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/time-concepts/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/time-concepts/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/time-concepts/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/time-concepts/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/transforming/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/transforming/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/transforming/kafka/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/transforming/kafka/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/transforming/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/transforming/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/transforming/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/transforming/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/transforming/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/transforming/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/transforming/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/transforming/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/transforming/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/transforming/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/tumbling-windows/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/tumbling-windows/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/tumbling-windows/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/tumbling-windows/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/tumbling-windows/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/tumbling-windows/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/tumbling-windows/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/tumbling-windows/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/tumbling-windows/kstreams/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/tumbling-windows/kstreams/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/filtering/kstreams/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/udf/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/udf/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/udf/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/udf/ksql/markup/dev/make-docker-compose.adoc
+++ b/_includes/tutorials/udf/ksql/markup/dev/make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="dockerfile">{% include_raw tutorials/udf/ksql/code/docker-compose.yml %}</code></pre>

--- a/_includes/tutorials/window-final-result/kstreams/markup/dev/1_1-make-docker-compose.adoc
+++ b/_includes/tutorials/window-final-result/kstreams/markup/dev/1_1-make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (for Kafka in the cloud, see https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="yaml">{%

--- a/_includes/tutorials/window-final-result/kstreams/markup/dev/1_1-make-docker-compose.adoc
+++ b/_includes/tutorials/window-final-result/kstreams/markup/dev/1_1-make-docker-compose.adoc
@@ -1,4 +1,4 @@
-Next, create the following `docker-compose.yml` file to obtain Confluent Platform:
+Next, create the following `docker-compose.yml` file to obtain Confluent Platform (or if you want Kafka in the cloud, check out https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]):
 
 +++++
 <pre class="snippet"><code class="yaml">{%


### PR DESCRIPTION
### Description

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/earlier_cta_non_ccloud
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` -->
<!-- - [ ] Implement good test cases -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
