### PR TITLE
MINOR: Additional changes from ccloud to confluent

### DIFF
--- a/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/check-connector.sh
+++ b/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/check-connector.sh
@@ -1,1 +1,1 @@
-ccloud connector list
+confluent connector list

--- a/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/create-cloud-api-key.sh
+++ b/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/create-cloud-api-key.sh
@@ -1,1 +1,1 @@
-ccloud api-key create --resource cloud -o json > cloud-api-key.json
+confluent api-key create --resource cloud -o json > cloud-api-key.json

--- a/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/create-connector.sh
+++ b/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/create-connector.sh
@@ -1,1 +1,1 @@
-ccloud connector create --config datagen-source-config.json 
+confluent connector create --config datagen-source-config.json 

--- a/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/delete-connector.sh
+++ b/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/delete-connector.sh
@@ -1,1 +1,1 @@
-ccloud connector delete <connector id>
+confluent connector delete <connector id>

--- a/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/list-connector.sh
+++ b/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/list-connector.sh
@@ -1,1 +1,1 @@
-ccloud connector list
+confluent connector list

--- a/_includes/tutorials/kafka-connect-datagen/confluent/markup/dev/provision-connector.adoc
+++ b/_includes/tutorials/kafka-connect-datagen/confluent/markup/dev/provision-connector.adoc
@@ -1,6 +1,6 @@
 You can choose one of two options for provisioning a fully managed Kafka Connect Datagen source connector in Confluent Cloud.  Either option will use the connector configuration file `datagen-source-config.json` that you created in the previous step.
 
-*Option 1.* You can use the Confluent CLI which provides the `ccloud connector create` command allowing you to pass in the configuration file from the previous step.
+*Option 1.* You can use the Confluent CLI which provides the `confluent connector create` command allowing you to pass in the configuration file from the previous step.
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/create-connector.sh %}</code></pre>
@@ -18,7 +18,7 @@ The `cloud-api-key.json` file now contains an API key and secret authorized to c
 
 You will also need to set:
 
-- Confluent Cloud environment id into the configuration parameter `ENVIRONMENT` (use the command `ccloud environment list` to view the active environment).
+- Confluent Cloud environment id into the configuration parameter `ENVIRONMENT` (use the command `confluent environment list` to view the active environment).
 
 - Kafka cluster id into the configuration parameter `CLUSTER` (use the command `confluent kafka cluster list` to view the active cluster).
 


### PR DESCRIPTION
### Description

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->
Some additional files that need to migrate to `ccloud` command to `confluent`

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` -->
<!-- - [ ] Implement good test cases -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
