### PR TITLE
Fix link to Stream Processing Use Cases

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -100,7 +100,7 @@
                 and Integrate</a>
               <a href="https://developer.confluent.io/?build=operate#designbuildrun">Admins: Operate</a>
               <a href="https://developer.confluent.io/demos-examples/">Demos &amp; In-depth Examples</a>
-              <a target="_blank" rel="noopener noreferrer" href="https://kafka-tutorials.confluent.io/use-cases.html">Stream Processing Use Cases</a>
+              <a href="https://developer.confluent.io/tutorials/use-cases.html">Stream Processing Use Cases</a>
               <a href="https://developer.confluent.io/100-days-of-code/">100 Days Of Code</a>
             </div>
           </div>
@@ -192,7 +192,7 @@
                 and Integrate</a></li>
             <li><a href="https://developer.confluent.io/?build=operate#designbuildrun">Admins: Operate</a></li>
             <li><a href="https://developer.confluent.io/demos-examples/">Demos &amp; In-depth Examples</a></li>
-            <li><a href="https://kafka-tutorials.confluent.io/use-cases.html">Stream Processing Use Cases</a></li>
+            <li><a href="https://developer.confluent.io/tutorials/use-cases.html">Stream Processing Use Cases</a></li>
             <li><a href="https://developer.confluent.io/100-days-of-code/">100 Days Of Code</a></li>
           </ul>
         </li>


### PR DESCRIPTION
### Description

Fix nav for `Stream Processing Use Cases`

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
