### PR TITLE
Make index landing page href relative for buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
             </h1>
             <h2 class="subtitle">From Idea to Proof-of-concept: Learn the Apache Kafka® fundamentals quickly with our functional tutorials, then explore the most popular stream processing use cases with recipes powered by ksqlDB so you can take immediate action, 100% in the cloud. <a href="https://www.confluent.io/confluent-cloud/tryfree/">Get started here</a></h2>
             <div class="ctas">
-                <a href="index.html" class="btn-midnight-white-outline">Functional Tutorials</a>
-                <a href="use-cases.html" class="btn-midnight">Use Case Recipes</a>
+                <a href="{{ "/index.html" | relative_url }}" class="btn-midnight-white-outline">Functional Tutorials</a>
+                <a href="{{ "/use-cases.html" | relative_url }}" class="btn-midnight">Use Case Recipes</a>
             </div>
           </div>
         </div>

--- a/use-cases-phase2.html
+++ b/use-cases-phase2.html
@@ -32,8 +32,8 @@
             </h1>
             <h2 class="subtitle">From Idea to Proof-of-concept: Learn the Apache Kafka® fundamentals quickly with our functional tutorials, then explore the most popular stream processing use cases with recipes powered by ksqlDB so you can take immediate action, 100% in the cloud. <a href="https://www.confluent.io/confluent-cloud/tryfree/">Get started here</a></h2>
             <div class="ctas">
-                <a href="index.html" class="btn-midnight">Functional Tutorials</a>
-                <a href="use-cases-phase2.html" class="btn-midnight-white-outline">Use Case Recipes</a>
+                <a href="{{ "/index.html" | relative_url }}" class="btn-midnight">Functional Tutorials</a>
+                <a href="{{ "/use-cases.html" | relative_url }}" class="btn-midnight-white-outline">Use Case Recipes</a>
             </div>
           </div>
         </div>

--- a/use-cases-phase2.html
+++ b/use-cases-phase2.html
@@ -33,7 +33,7 @@
             <h2 class="subtitle">From Idea to Proof-of-concept: Learn the Apache Kafka® fundamentals quickly with our functional tutorials, then explore the most popular stream processing use cases with recipes powered by ksqlDB so you can take immediate action, 100% in the cloud. <a href="https://www.confluent.io/confluent-cloud/tryfree/">Get started here</a></h2>
             <div class="ctas">
                 <a href="{{ "/index.html" | relative_url }}" class="btn-midnight">Functional Tutorials</a>
-                <a href="{{ "/use-cases.html" | relative_url }}" class="btn-midnight-white-outline">Use Case Recipes</a>
+                <a href="{{ "/use-cases-phase2.html" | relative_url }}" class="btn-midnight-white-outline">Use Case Recipes</a>
             </div>
           </div>
         </div>

--- a/use-cases.html
+++ b/use-cases.html
@@ -32,8 +32,8 @@
             </h1>
             <h2 class="subtitle">From Idea to Proof-of-concept: Learn the Apache Kafka® fundamentals quickly with our functional tutorials, then explore the most popular stream processing use cases with recipes powered by ksqlDB so you can take immediate action, 100% in the cloud. <a href="https://www.confluent.io/confluent-cloud/tryfree/">Get started here</a></h2>
             <div class="ctas">
-                <a href="index.html" class="btn-midnight">Functional Tutorials</a>
-                <a href="use-cases.html" class="btn-midnight-white-outline">Use Case Recipes</a>
+                <a href="{{ "/index.html" | relative_url }}" class="btn-midnight">Functional Tutorials</a>
+                <a href="{{ "/use-cases.html" | relative_url }}" class="btn-midnight-white-outline">Use Case Recipes</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Description

Make links relative on landing page (for buttons)

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/fix_index_buttons
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
