### PR TITLE
Add new recipe for ML model retraining

### DIFF
--- a/_data/harnesses/model-retraining/confluent.yml
+++ b/_data/harnesses/model-retraining/confluent.yml
@@ -1,0 +1,67 @@
+answer:
+  steps:
+    - title:
+      content:
+        - action: skip
+          render:
+            file: tutorials/model-retraining/confluent/markup/dev/answer-short.adoc
+
+dev:
+  steps:
+    - title: Setup your environment
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/provision-cluster.adoc
+
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ccloud_setup.adoc
+
+    - title: Read the data in
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/connect.adoc
+
+        - action: skip
+          render:
+            file: tutorials/model-retraining/confluent/markup/dev/source.adoc
+
+        - action: skip
+          render:
+            file: shared/markup/ccloud/manual_insert.adoc
+
+    - title: ksqlDB code
+      content:
+        - action: skip
+          render:
+            file: tutorials/model-retraining/confluent/markup/dev/ksqlDB.adoc
+
+        - action: skip
+          render:
+            file: shared/markup/ccloud/ksqlb_processing_intro.adoc
+
+        - action: skip
+          render:
+            file: tutorials/model-retraining/confluent/markup/dev/process.adoc
+
+        - action: skip
+          render:
+            file: shared/markup/ccloud/manual_cue.adoc
+
+        - action: skip
+          render:
+            file: tutorials/model-retraining/confluent/markup/dev/manual.adoc
+
+    - title: Write the data out
+      content:
+        - action: skip
+          render:
+            file: tutorials/model-retraining/confluent/markup/dev/sink.adoc
+
+    - title: Cleanup
+      content:
+        - action: skip
+          render:
+            file: shared/markup/ccloud/cleanup.adoc

--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -1049,3 +1049,12 @@ audit-logs:
   tutorial-id: "23"
   status:
     confluent: enabled
+
+model-retraining:
+  title: "Machine Learning Model Retraining"
+  meta-description: "This recipe demonstrates how to use ksqlDB to evaluate the predictions of a machine learning model and send data to retrain the model when needed."
+  slug: "/model-retraining"
+  introduction: "Machine learning provides valuable insights to an organization, and tools like Apache Kafka, Kafka Connect, and ksqlDB allow us to build powerful machine learning pipelines. We can also use these tools to extend an existing machine learning pipeline. In this recipe, we'll use Connect and ksqlDB to read the results of an existing pipeline, determine the accuracy of those results, and send data to retrain our model.  This recipe is based on the excellent blog post <a href='https://www.confluent.io/blog/how-baader-built-a-predictive-analytics-machine-learning-system-with-kafka-and-rstudio/'>Apache Kafka and R: Real-Time Prediction and Model (Re)training</a>, by Patrick Neff."
+  tutorial-id: "24"
+  status:
+    confluent: enabled

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/manual.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/manual.sql
@@ -1,0 +1,21 @@
+INSERT INTO predicted_weight VALUES ('101', 'Salmon', 17.33, 74.55, 3.78);
+INSERT INTO predicted_weight VALUES ('102', 'Salmon', 19.11, 82.19, 4.17);
+INSERT INTO predicted_weight VALUES ('103', 'Salmon', 21.07, 90.62, 4.6);
+INSERT INTO predicted_weight VALUES ('104', 'Bass', 15.44, 56.23, 2.54);
+INSERT INTO predicted_weight VALUES ('105', 'Bass', 17.02, 62, 2.8);
+INSERT INTO predicted_weight VALUES ('106', 'Bass', 18.76, 68.34, 3.09);
+INSERT INTO predicted_weight VALUES ('107', 'Trout', 13.34, 64.05, 1.47);
+INSERT INTO predicted_weight VALUES ('108', 'Trout', 14.71, 70.61, 1.62);
+INSERT INTO predicted_weight VALUES ('109', 'Trout', 16.22, 77.85, 1.79);
+INSERT INTO predicted_weight VALUES ('110', 'Trout', 17.03, 81.74, 1.88);
+
+INSERT INTO actual_weight VALUES ('101', 'Salmon', 4.38);
+INSERT INTO actual_weight VALUES ('102', 'Salmon', 3.17);
+INSERT INTO actual_weight VALUES ('103', 'Salmon', 5.6);
+INSERT INTO actual_weight VALUES ('104', 'Bass', 5.54);
+INSERT INTO actual_weight VALUES ('105', 'Bass', 1.8);
+INSERT INTO actual_weight VALUES ('106', 'Bass', 4.09);
+INSERT INTO actual_weight VALUES ('107', 'Trout', 2.47);
+INSERT INTO actual_weight VALUES ('108', 'Trout', 2.62);
+INSERT INTO actual_weight VALUES ('109', 'Trout', 2.79);
+INSERT INTO actual_weight VALUES ('110', 'Trout', 2.88);

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/process.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/process.sql
@@ -1,0 +1,66 @@
+SET 'auto.offset.reset' = 'earliest';
+
+-- Create stream of predictions
+CREATE STREAM predicted_weight(
+  "Fish_Id" VARCHAR KEY,
+  "Species" VARCHAR,
+  "Height" DOUBLE,
+  "Length" DOUBLE,
+  "Prediction" DOUBLE
+  )
+WITH(
+  KAFKA_TOPIC = 'kt.mdb.weight-prediction', 
+  VALUE_FORMAT = 'JSON',
+  PARTITIONS = 6
+);
+
+-- Create stream of actual weights
+CREATE STREAM actual_weight(
+  "Fish_Id" VARCHAR KEY,
+  "Species" VARCHAR,
+  "Weight" DOUBLE
+  )
+WITH(
+  KAFKA_TOPIC = 'kt.mdb.machine-weight', 
+  VALUE_FORMAT = 'JSON',
+  PARTITIONS = 6
+);
+
+-- Create stream joining predictions with actual weights
+CREATE STREAM diff_weight
+WITH(
+  KAFKA_TOPIC = 'diff_weight', 
+  VALUE_FORMAT = 'JSON'
+)
+AS SELECT
+   -- This fake Key field will give us something to group by in the next step
+   'Key' AS "Key", 
+   predicted_weight."Fish_Id" AS "Fish_Id",
+   predicted_weight."Species" AS "Species",
+   predicted_weight."Length" AS "Length",
+   predicted_weight."Height" AS "Height",
+   predicted_weight."Prediction" AS "PredictedWeight",
+   actual_weight."Weight" AS "ActualWeight",
+   ROUND(ABS(predicted_weight."Prediction" - actual_weight."Weight") / actual_weight."Weight", 3) AS "Error"
+FROM predicted_weight
+INNER JOIN actual_weight
+WITHIN 1 MINUTE
+GRACE PERIOD 1 MINUTE
+ON predicted_weight."Fish_Id" = actual_weight."Fish_Id";
+
+-- Create table of one minute aggregates with over 15% error rate
+CREATE TABLE retrain_weight
+WITH(
+  KAFKA_TOPIC = 'retrain_weight', 
+  VALUE_FORMAT = 'JSON'
+)
+AS SELECT
+   "Key",
+   COLLECT_SET("Species") AS "Species",
+   EARLIEST_BY_OFFSET("Fish_Id") AS "Fish_Id_Start",
+   LATEST_BY_OFFSET("Fish_Id") AS "Fish_Id_End",
+   AVG("Error") AS "ErrorAvg"
+FROM DIFF_WEIGHT
+WINDOW TUMBLING (SIZE 1 MINUTE, GRACE PERIOD 1 MINUTE)
+GROUP BY "Key"
+HAVING ROUND(AVG(DIFF_WEIGHT.`Error`), 2) > 0.15;

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/process.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/process.sql
@@ -2,13 +2,12 @@ SET 'auto.offset.reset' = 'earliest';
 
 -- Create stream of predictions
 CREATE STREAM predicted_weight(
-  "Fish_Id" VARCHAR KEY,
-  "Species" VARCHAR,
-  "Height" DOUBLE,
-  "Length" DOUBLE,
-  "Prediction" DOUBLE
-  )
-WITH(
+  fish_id VARCHAR KEY,
+  species VARCHAR,
+  height DOUBLE,
+  length DOUBLE,
+  prediction DOUBLE
+) WITH (
   KAFKA_TOPIC = 'kt.mdb.weight-prediction', 
   VALUE_FORMAT = 'JSON',
   PARTITIONS = 6
@@ -16,51 +15,42 @@ WITH(
 
 -- Create stream of actual weights
 CREATE STREAM actual_weight(
-  "Fish_Id" VARCHAR KEY,
-  "Species" VARCHAR,
-  "Weight" DOUBLE
-  )
-WITH(
+  fish_id VARCHAR KEY,
+  species VARCHAR,
+  weight DOUBLE
+) WITH (
   KAFKA_TOPIC = 'kt.mdb.machine-weight', 
   VALUE_FORMAT = 'JSON',
   PARTITIONS = 6
 );
 
 -- Create stream joining predictions with actual weights
-CREATE STREAM diff_weight
-WITH(
-  KAFKA_TOPIC = 'diff_weight', 
-  VALUE_FORMAT = 'JSON'
-)
-AS SELECT
-   -- This fake Key field will give us something to group by in the next step
-   'Key' AS "Key", 
-   predicted_weight."Fish_Id" AS "Fish_Id",
-   predicted_weight."Species" AS "Species",
-   predicted_weight."Length" AS "Length",
-   predicted_weight."Height" AS "Height",
-   predicted_weight."Prediction" AS "PredictedWeight",
-   actual_weight."Weight" AS "ActualWeight",
-   ROUND(ABS(predicted_weight."Prediction" - actual_weight."Weight") / actual_weight."Weight", 3) AS "Error"
+CREATE STREAM diff_weight WITH (KAFKA_TOPIC = 'diff_weight') AS
+  SELECT
+   -- This fake key field will give us something to group by in the next step
+   'key' AS key, 
+   predicted_weight.fish_id AS fish_id,
+   predicted_weight.species AS species,
+   predicted_weight.length AS length,
+   predicted_weight.height AS height,
+   predicted_weight.prediction AS prediction,
+   actual_weight.weight AS actual,
+   ROUND(ABS(predicted_weight.prediction - actual_weight.weight) / actual_weight.weight, 3) AS Error
 FROM predicted_weight
 INNER JOIN actual_weight
 WITHIN 1 MINUTE
 GRACE PERIOD 1 MINUTE
-ON predicted_weight."Fish_Id" = actual_weight."Fish_Id";
+ON predicted_weight.fish_id = actual_weight.fish_id;
 
 -- Create table of one minute aggregates with over 15% error rate
-CREATE TABLE retrain_weight
-WITH(
-  KAFKA_TOPIC = 'retrain_weight', 
-  VALUE_FORMAT = 'JSON'
-)
-AS SELECT
-   "Key",
-   COLLECT_SET("Species") AS "Species",
-   EARLIEST_BY_OFFSET("Fish_Id") AS "Fish_Id_Start",
-   LATEST_BY_OFFSET("Fish_Id") AS "Fish_Id_End",
-   AVG("Error") AS "ErrorAvg"
-FROM DIFF_WEIGHT
+CREATE TABLE retrain_weight WITH (KAFKA_TOPIC = 'retrain_weight') AS
+ SELECT
+   key,
+   COLLECT_SET(species) AS species,
+   EARLIEST_BY_OFFSET(fish_id) AS fish_id_start,
+   LATEST_BY_OFFSET(fish_id) AS fish_id_end,
+   AVG(Error) AS ErrorAvg
+FROM diff_weight
 WINDOW TUMBLING (SIZE 1 MINUTE, GRACE PERIOD 1 MINUTE)
-GROUP BY "Key"
-HAVING ROUND(AVG(DIFF_WEIGHT.`Error`), 2) > 0.15;
+GROUP BY key
+HAVING ROUND(AVG(diff_weight.Error), 2) > 0.15;

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.json
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.json
@@ -8,7 +8,7 @@
     "connection.host"          : "<database-host-address>",
     "connection.user"          : "<my-username>",
     "connection.password"      : "<my-password>",
-    "topics"                   : "weight-diff",
+    "topics"                   : "diff_weight",
     "max.num.retries"          : "3",
     "retries.defer.timeout"    : "5000",
     "max.batch.size"           : "0",
@@ -24,7 +24,7 @@
     "kafka.auth.mode"          : "KAFKA_API_KEY",
     "kafka.api.key"            : "<my-kafka-api-key>",
     "kafka.api.secret"         : "<my-kafka-api-secret>",
-    "topics"                   : "weight-retrain",
+    "topics"                   : "retrain_weight",
     "tasks.max"                : "1",
     "http.api.url"             : "<training-endpoint-url>",
     "request.method"           : "POST"

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.json
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.json
@@ -1,0 +1,31 @@
+{
+    "connector.class"          : "MongoDbAtlasSink",
+    "name"                     : "weight-data",
+    "kafka.auth.mode"          : "KAFKA_API_KEY",
+    "kafka.api.key"            : "<my-kafka-api-key",
+    "kafka.api.secret"         : "<my-kafka-api-secret>",
+    "input.data.format"        : "JSON",
+    "connection.host"          : "<database-host-address>",
+    "connection.user"          : "<my-username>",
+    "connection.password"      : "<my-password>",
+    "topics"                   : "weight-diff",
+    "max.num.retries"          : "3",
+    "retries.defer.timeout"    : "5000",
+    "max.batch.size"           : "0",
+    "database"                 : "mdb",
+    "collection"               : "training-data",
+    "tasks.max"                : "1"
+}
+
+{
+    "connector.class"          : "HttpSink",
+    "input.data.format"        : "JSON",
+    "name"                     : "retrain-trigger",
+    "kafka.auth.mode"          : "KAFKA_API_KEY",
+    "kafka.api.key"            : "<my-kafka-api-key>",
+    "kafka.api.secret"         : "<my-kafka-api-secret>",
+    "topics"                   : "weight-retrain",
+    "tasks.max"                : "1",
+    "http.api.url"             : "<training-endpoint-url>",
+    "request.method"           : "POST"
+}

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.sql
@@ -8,7 +8,7 @@ CREATE SINK CONNECTOR training-data WITH (
     'connection.host'          = '<database-host-address>',
     'connection.user'          = '<my-username>',
     'connection.password'      = '<my-password>',
-    'topics'                   = 'weight-diff',
+    'topics'                   = 'diff_weight',
     'max.num.retries'          = '3',
     'retries.defer.timeout'    = '5000',
     'max.batch.size'           = '0',
@@ -24,7 +24,7 @@ CREATE SINK CONNECTOR retraining-trigger WITH (
     'kafka.auth.mode'          = 'KAFKA_API_KEY',
     'kafka.api.key'            = '<my-kafka-api-key>',
     'kafka.api.secret'         = '<my-kafka-api-secret>',
-    'topics'                   = 'weight-retrain',
+    'topics'                   = 'retrain_weight',
     'tasks.max'                = '1',
     'http.api.url'             = '<training-endpoint-url>',
     'request.method'           = 'POST'

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.sql
@@ -1,0 +1,31 @@
+CREATE SINK CONNECTOR training-data WITH (
+    'connector.class'          = 'MongoDbAtlasSink',
+    'name'                     = 'weight-data', 
+    'kafka.auth.mode'          = 'KAFKA_API_KEY',
+    'kafka.api.key'            = '<my-kafka-api-key',
+    'kafka.api.secret'         = '<my-kafka-api-secret>',
+    'input.data.format'        = 'JSON',
+    'connection.host'          = '<database-host-address>',
+    'connection.user'          = '<my-username>',
+    'connection.password'      = '<my-password>',
+    'topics'                   = 'weight-diff',
+    'max.num.retries'          = '3',
+    'retries.defer.timeout'    = '5000',
+    'max.batch.size'           = '0',
+    'database'                 = 'mdb',
+    'collection'               = 'training-data',
+    'tasks.max'                = '1'
+);     
+
+CREATE SINK CONNECTOR retraining-trigger WITH (
+    'connector.class'          = 'HttpSink',
+    'input.data.format'        = 'JSON',
+    'name'                     = 'retrain-trigger',
+    'kafka.auth.mode'          = 'KAFKA_API_KEY',
+    'kafka.api.key'            = '<my-kafka-api-key>',
+    'kafka.api.secret'         = '<my-kafka-api-secret>',
+    'topics'                   = 'weight-retrain',
+    'tasks.max'                = '1',
+    'http.api.url'             = '<training-endpoint-url>',
+    'request.method'           = 'POST'
+);

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.json
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.json
@@ -1,0 +1,38 @@
+{
+  "connector.class"        : "MongoDbAtlasSource",
+  "name"                   : "recipe-model-retrain-predictions",
+  "kafka.auth.mode"        : "KAFKA_API_KEY",
+  "kafka.api.key"          : "<my-kafka-api-key>",
+  "kafka.api.secret"       : "<my-kafka-api-secret>",
+  "connection.host"        : "<database-host-address>",
+  "connection.user"        : "<database-username>",
+  "connection.password"    : "<database-password>",
+  "topic.prefix"           : "kt",
+  "database"               : "mdb",
+  "collection"             : "weight-prediction",
+  "poll.await.time.ms"     : "5000",
+  "poll.max.batch.size"    : "1000",
+  "copy.existing"          : "true",
+  "output.data.format"     : "JSON",
+  "tasks.max"              : "1"
+}
+
+{
+  "connector.class"        : "MongoDbAtlasSource",
+  "name"                   : "recipe-model-retrain-weights",
+  "kafka.auth.mode"        : "KAFKA_API_KEY",
+  "kafka.api.key"          : "<my-kafka-api-key>",
+  "kafka.api.secret"       : "<my-kafka-api-secret>",
+  "connection.host"        : "<database-host-address>",
+  "connection.user"        : "<database-username>",
+  "connection.password"    : "<database-password>",
+  "topic.prefix"           : "kt",
+  "database"               : "mdb",
+  "collection"             : "machine-weight",
+  "poll.await.time.ms"     : "5000",
+  "poll.max.batch.size"    : "1000",
+  "copy.existing"          : "true",
+  "output.data.format"     : "JSON",
+  "tasks.max"              : "1"
+}
+

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.sql
@@ -1,0 +1,38 @@
+-- Stream of fish weight predictions
+CREATE SOURCE CONNECTOR weight-predictions WITH (
+  'connector.class'        = 'MongoDbAtlasSource',
+  'name'                   = 'model-retrain-weight-predictions',
+  'kafka.api.key'          = '<my-kafka-api-key>',
+  'kafka.api.secret'       = '<my-kafka-api-secret>',
+  'connection.host'        = '<database-host-address>',
+  'connection.user'        = '<database-username>',
+  'connection.password'    = '<database-password>',
+  'topic.prefix'           = 'kt',
+  'database'               = 'mdb',
+  'collection'             = 'weight-prediction',
+  'poll.await.time.ms'     = '5000',
+  'poll.max.batch.size'    = '1000',
+  'copy.existing'          = 'true',
+  'output.data.format'     = 'JSON',
+  'tasks.max'              = '1'
+);
+
+-- Stream of actual fish weights
+CREATE SOURCE CONNECTOR actual-weights WITH (
+  'connector.class'        = 'MongoDbAtlasSource',
+  'name'                   = 'model-retrain-actual-weights',
+  'kafka.api.key'          = '<my-kafka-api-key>',
+  'kafka.api.secret'       = '<my-kafka-api-secret>',
+  'connection.host'        = '<database-host-address>',
+  'connection.user'        = '<database-username>',
+  'connection.password'    = '<database-password>',
+  'topic.prefix'           = 'kt',
+  'database'               = 'mdb',
+  'collection'             = 'machine-weight',
+  'poll.await.time.ms'     = '5000',
+  'poll.max.batch.size'    = '1000',
+  'copy.existing'          = 'true',
+  'output.data.format'     = 'JSON',
+  'tasks.max'              = '1'
+);
+

--- a/_includes/tutorials/model-retraining/confluent/markup/dev/answer-short.adoc
+++ b/_includes/tutorials/model-retraining/confluent/markup/dev/answer-short.adoc
@@ -1,0 +1,1 @@
+Run this tutorial in link:https://www.confluent.io/confluent-cloud/tryfree[Confluent Cloud]

--- a/_includes/tutorials/model-retraining/confluent/markup/dev/ksqlDB.adoc
+++ b/_includes/tutorials/model-retraining/confluent/markup/dev/ksqlDB.adoc
@@ -1,0 +1,2 @@
+Start by creating a ksqlDB stream for each of our two input topics coming from Connect. Then create another stream to join those two streams on `Fish_Id`. Finally, create a ksqlDB table with a windowed aggregation of our joined stream, where the average error rate is over 15%. This table will be used to trigger our model retraining process.
+

--- a/_includes/tutorials/model-retraining/confluent/markup/dev/manual.adoc
+++ b/_includes/tutorials/model-retraining/confluent/markup/dev/manual.adoc
@@ -1,0 +1,3 @@
+++++
+<pre class="snippet"><code class="sql">{% include_raw tutorials/model-retraining/confluent/code/tutorial-steps/dev/manual.sql %}</code></pre>
+++++

--- a/_includes/tutorials/model-retraining/confluent/markup/dev/process.adoc
+++ b/_includes/tutorials/model-retraining/confluent/markup/dev/process.adoc
@@ -1,0 +1,3 @@
+++++
+<pre class="snippet"><code class="sql">{% include_raw tutorials/model-retraining/confluent/code/tutorial-steps/dev/process.sql %}</code></pre>
+++++

--- a/_includes/tutorials/model-retraining/confluent/markup/dev/sink.adoc
+++ b/_includes/tutorials/model-retraining/confluent/markup/dev/sink.adoc
@@ -1,0 +1,5 @@
+Now we'll use a MongoDB sink connector to send the combined predictions and actual weights to a database, and the HTTP sink connector to trigger the retraining process.
+
+++++
+<pre class="snippet"><code class="json">{% include_raw tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.json %}</code></pre>
+++++

--- a/_includes/tutorials/model-retraining/confluent/markup/dev/source.adoc
+++ b/_includes/tutorials/model-retraining/confluent/markup/dev/source.adoc
@@ -1,0 +1,5 @@
+The existing pipeline, which is predicting the weight of fish based on size and species, stores its results in two MongoDB collections, which are used by other processes downstream. One collection contains the data fed to the model, along with the prediction. The other contains the actual weight as determined by a later step in the process. For this recipe, we'll use Connect to make this data available to our ksqlDB application.
+
+++++
+<pre class="snippet"><code class="json">{% include_raw tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.json %}</code></pre>
+++++

--- a/tutorials/model-retraining/confluent.html
+++ b/tutorials/model-retraining/confluent.html
@@ -1,0 +1,6 @@
+---
+layout: recipe
+permalink: /model-retraining/confluent
+stack: confluent
+static_data: model-retraining
+---

--- a/use-cases-phase2.html
+++ b/use-cases-phase2.html
@@ -95,6 +95,7 @@
             <li><a href="{{ "/fleet-management/confluent.html" | relative_url }}">Optimize fleet management</a></li>
             <li><a href="{{ "/inventory/confluent.html" | relative_url }}">Optimize omni-channel inventory</a></li>
             <li><a href="{{ "/next-best-offer/confluent.html" | relative_url }}">(NEW) Next Best Offer for Banking</a></li>
+            <li><a href="{{ "/model-retraining/confluent.html" | relative_url }}">(NEW) Machine learning model retraining</a></li>
           </ul>
           <!--div id="show"><a class="button is-small is-fullwidth">More</a></div-->
         </div>


### PR DESCRIPTION
### Description

New recipe port over

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/model_retraining_recipe/model-retraining/confluent.html

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
