### PR TITLE
Making footer links absolute

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -150,11 +150,11 @@
       </nav>
     </div>
     <div class="copyright">
-      <div class="copyright-links"><a target="_blank" rel="noopener noreferrer" href="terms-of-use/">Terms &amp;
+      <div class="copyright-links"><a target="_blank" rel="noopener noreferrer" href="https://www.confluent.io/terms-of-use/">Terms &amp;
           Conditions</a> | <a target="_blank" rel="noopener noreferrer"
-          href="legal/confluent-privacy-statement/">Privacy Policy</a> | <a target="_blank" rel="noopener noreferrer"
-          href="legal/confluent-privacy-statement/#california-privacy-rights">Do Not Sell My Information</a> | <a
-          target="_blank" rel="noopener noreferrer" href="modern-slavery-policy/">Modern Slavery Policy</a> | <a
+          href="https://www.confluent.io/legal/confluent-privacy-statement/">Privacy Policy</a> | <a target="_blank" rel="noopener noreferrer"
+          href="https://www.confluent.io/legal/confluent-privacy-statement/#california-privacy-rights">Do Not Sell My Information</a> | <a
+          target="_blank" rel="noopener noreferrer" href="https://www.confluent.io/modern-slavery-policy/">Modern Slavery Policy</a> | <a
           rel=" noreferrer" href="/#">Cookie Settings</a></div>
       <p class="copy">
         Copyright © Confluent, Inc. 2014-<span>2021</span>. Apache, Apache Kafka, Kafka, and associated open source


### PR DESCRIPTION
### Description

Fixing links in the footer -- this was brought up in Slack.

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
