### PR TITLE
Breadcrumbs on the tutorial and use-case pages

### DIFF
--- a/_includes/tutorial-content.html
+++ b/_includes/tutorial-content.html
@@ -178,7 +178,7 @@
   <section class="section">
     <div class="container">
       <ul class="breadcrumb">
-        <li><a href="/">&lt; Back to tutorials</a></li>
+        <li><a href="/tutorials/">&lt; Back to tutorials</a></li>
       </ul>
     </div>
 

--- a/_includes/tutorial-content.html
+++ b/_includes/tutorial-content.html
@@ -174,13 +174,4 @@
   </div>
 </section>
 {% endif %}
-
-  <section class="section">
-    <div class="container">
-      <ul class="breadcrumb">
-        <li><a href="/tutorials/">&lt; Back to tutorials</a></li>
-      </ul>
-    </div>
-
-  </section>
 </div>

--- a/_includes/tutorial-content.html
+++ b/_includes/tutorial-content.html
@@ -118,7 +118,7 @@
               {% endif %}
 
               {% endfor %}
-                
+
               </div>
             </div>
           </div>
@@ -174,4 +174,13 @@
   </div>
 </section>
 {% endif %}
+
+  <section class="section">
+    <div class="container">
+      <ul class="breadcrumb">
+        <li><a href="/">&lt; Back to tutorials</a></li>
+      </ul>
+    </div>
+
+  </section>
 </div>

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -35,7 +35,7 @@
     <div class="hero-body">
       <div class="container">
         <ul class="breadcrumb">
-          <li><a href="/tutorials/use-cases">< Back to tutorials</a></li>
+          <li><a href="/tutorials/use-cases">&lt; Back to tutorials</a></li>
         </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -31,10 +31,12 @@
 </head>
 <body class="pg-tutorial">
   {% include nav.html %}
-
   <section class="hero">
     <div class="hero-body">
       <div class="container">
+        <ul class="breadcrumb">
+          <li><a href="/tutorials/use-cases">< Back to tutorials</a></li>
+        </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>
         {% endif %}
@@ -122,6 +124,14 @@
       {% include contribute-tutorial-lang.html %}
       {% else %}
       {% include tutorial-content.html %}
+      <section class="section">
+        <div class="container">
+          <ul class="breadcrumb">
+            <li><a href="/tutorials/use-cases">&lt; Back to tutorials</a></li>
+          </ul>
+        </div>
+
+      </section>
       {% endif %}
     {% endif %}
   </div>

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -130,7 +130,6 @@
             <li><a href="/tutorials/use-cases.html">&lt; Back to tutorials</a></li>
           </ul>
         </div>
-
       </section>
       {% endif %}
     {% endif %}

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -35,7 +35,7 @@
     <div class="hero-body">
       <div class="container">
         <ul class="breadcrumb">
-          <li><a href="/tutorials/use-cases">&lt; Back to tutorials</a></li>
+          <li><a href="/tutorials/use-cases.html">&lt; Back to tutorials</a></li>
         </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>
@@ -127,7 +127,7 @@
       <section class="section">
         <div class="container">
           <ul class="breadcrumb">
-            <li><a href="/tutorials/use-cases">&lt; Back to tutorials</a></li>
+            <li><a href="/tutorials/use-cases.html">&lt; Back to tutorials</a></li>
           </ul>
         </div>
 

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -35,6 +35,9 @@
   <section class="hero">
     <div class="hero-body">
       <div class="container">
+        <ul class="breadcrumb">
+          <li><a href="/">< Back to tutorials</a></li>
+        </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>
         {% endif %}

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -269,7 +269,6 @@
             <li><a href="/tutorials/">&lt; Back to tutorials</a></li>
           </ul>
         </div>
-
       </section>
       {% endif %}
     {% endif %}

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -36,7 +36,7 @@
     <div class="hero-body">
       <div class="container">
         <ul class="breadcrumb">
-          <li><a href="/">< Back to tutorials</a></li>
+          <li><a href="/tutorials/">< Back to tutorials</a></li>
         </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -36,7 +36,7 @@
     <div class="hero-body">
       <div class="container">
         <ul class="breadcrumb">
-          <li><a href="/tutorials/">< Back to tutorials</a></li>
+          <li><a href="/tutorials/">&lt; Back to tutorials</a></li>
         </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -263,6 +263,14 @@
       {% include contribute-tutorial-lang.html %}
       {% else %}
       {% include tutorial-content.html %}
+      <section class="section">
+        <div class="container">
+          <ul class="breadcrumb">
+            <li><a href="/tutorials/">&lt; Back to tutorials</a></li>
+          </ul>
+        </div>
+
+      </section>
       {% endif %}
     {% endif %}
   </div>

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -408,6 +408,9 @@ a {
   a {
     color: #edeaeafa !important;
   }
+  li {
+    margin-left: 0;
+  }
 }
 
 .section {

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -417,7 +417,7 @@ a {
   .container {
     .breadcrumb {
       a {
-        color: #000000 !important;
+        color: $color_black !important;
         font-weight: 900;
       }
     }

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -406,7 +406,7 @@ a {
 
 .breadcrumb {
   a {
-    color: #edeaeafa !important;
+    color: $color_ltGray !important;
   }
   li {
     margin-left: 0;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -406,7 +406,7 @@ a {
 
 .breadcrumb {
   a {
-    color: $color_ltGray !important;
+    color: $color_white !important;
   }
   li {
     margin-left: 0;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -404,6 +404,23 @@ a {
   }
 }
 
+.breadcrumb {
+  a {
+    color: #edeaeafa !important;
+  }
+}
+
+.section {
+  .container {
+    .breadcrumb {
+      a {
+        color: #000000 !important;
+        font-weight: 900;
+      }
+    }
+  }
+}
+
 .secondary-card-row,
 .third-card-row,
 .fourth-card-row,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,21 @@
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "kafka-tutorials",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "bulma": "0.7.4"
+      }
+    },
+    "node_modules/bulma": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.4.tgz",
+      "integrity": "sha512-krG2rP6eAX1WE0sf6O0SC/FUVSOBX4m1PBC2+GKLpb2pX0qanaDqcv9U2nu75egFrsHkI0zdWYuk/oGwoszVWg=="
+    }
+  },
   "dependencies": {
     "bulma": {
       "version": "0.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "kafka-tutorials",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "dependencies": {
     "bulma": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,8 @@
 {
   "name": "kafka-tutorials",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "kafka-tutorials",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "bulma": "0.7.4"
-      }
-    },
-    "node_modules/bulma": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.4.tgz",
-      "integrity": "sha512-krG2rP6eAX1WE0sf6O0SC/FUVSOBX4m1PBC2+GKLpb2pX0qanaDqcv9U2nu75egFrsHkI0zdWYuk/oGwoszVWg=="
-    }
-  },
   "dependencies": {
     "bulma": {
       "version": "0.7.4",


### PR DESCRIPTION
### Description

[This](https://app.asana.com/0/1201817272699202/1201822439776478) is the Asana story. In short, this PR is about adding two breadcrumbs: `Back to tutorials` on each tutorial & use-case page.

<img width="1440" alt="Screen Shot 2022-02-25 at 10 08 45 PM" src="https://user-images.githubusercontent.com/99665800/155738827-391c70e2-239b-45c5-bdc6-9836671fc54a.png">

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

<!-- ### Staging Docs -->

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

<!-- ### New tutorial checklist -->

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
