### PR TITLE
Add mention of Metrics API to count messages in topic

### DIFF
--- a/_includes/tutorials/count-messages/confluent/markup/dev/answer-short.adoc
+++ b/_includes/tutorials/count-messages/confluent/markup/dev/answer-short.adoc
@@ -3,3 +3,5 @@ If your Kafka topic is in https://www.confluent.io/confluent-cloud/tryfree/[Conf
 +++++
 <pre class="snippet"><code class="java">{% include_raw tutorials/count-messages/confluent/code/tutorial-steps/dev/03a-count-messages.sh %}</code></pre>
 +++++
+
+With the Confluent Cloud Metrics API, you could also sum up the values of the metric `io.confluent.kafka.server/received_records`, which is "The delta count of records received. Each sample is the number of records received since the previous data sample. The count is sampled every 60 seconds." See the https://api.telemetry.confluent.cloud/docs/descriptors/datasets/cloud[documentation] for details.


### PR DESCRIPTION
### Description

#1147 

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/metrics-api/how-to-count-messages-on-a-kafka-topic/confluent.html
