### PR TITLE
Nav Design, Build, Run update

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -198,13 +198,12 @@
           <ul>
             <li><a href="https://developer.confluent.io/patterns/">Event Streaming Patterns</a></li>
             <li><a href="https://developer.confluent.io/get-started/">Get Started With Your Favorite Language</a></li>
-            <li><a href="https://developer.confluent.io/tutorials/">Tutorials</a></li>
+            <li><a href="https://developer.confluent.io/tutorials/">Stream Processing Cookbook</a></li>
             <li><a href="https://developer.confluent.io/?build=apps#designbuildrun">Developers: Build Apps</a></li>
             <li><a href="https://developer.confluent.io/?build=pipelines#designbuildrun">Data Engineers: Build Pipelines
                 and Integrate</a></li>
             <li><a href="https://developer.confluent.io/?build=operate#designbuildrun">Admins: Operate</a></li>
             <li><a href="https://developer.confluent.io/demos-examples/">Demos &amp; In-depth Examples</a></li>
-            <li><a href="https://developer.confluent.io/tutorials/use-cases.html">Stream Processing Use Cases</a></li>
             <li><a href="https://developer.confluent.io/100-days-of-code/">100 Days Of Code</a></li>
           </ul>
         </li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -94,13 +94,12 @@
               <a target="_blank" rel="noopener noreferrer" href="https://developer.confluent.io/patterns/">Event
                 Streaming Patterns</a>
               <a href="https://developer.confluent.io/get-started/">Get Started With Your Favorite Language</a>
-              <a href="https://developer.confluent.io/tutorials/">Tutorials</a>
+              <a href="https://developer.confluent.io/tutorials/">Stream Processing Cookbook</a>
               <a href="https://developer.confluent.io/?build=apps#designbuildrun">Developers: Build Apps</a>
               <a href="https://developer.confluent.io/?build=pipelines#designbuildrun">Data Engineers: Build Pipelines
                 and Integrate</a>
               <a href="https://developer.confluent.io/?build=operate#designbuildrun">Admins: Operate</a>
               <a href="https://developer.confluent.io/demos-examples/">Demos &amp; In-depth Examples</a>
-              <a href="https://developer.confluent.io/tutorials/use-cases.html">Stream Processing Use Cases</a>
               <a href="https://developer.confluent.io/100-days-of-code/">100 Days Of Code</a>
             </div>
           </div>


### PR DESCRIPTION
### Description

https://app.asana.com/0/1201992122798715/1202002461829781

This updates the nav to change the `Tutorials` item to `Stream Processing Cookbook` and removes the other `Stream processing...` link.

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
