### PR TITLE
Fix back link to landing page and connector names (remove hyphens)

### DIFF
--- a/_includes/tutorials/ddos/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/ddos/confluent/code/tutorial-steps/dev/source.sql
@@ -1,7 +1,7 @@
 -- Example
-CREATE SOURCE CONNECTOR IF NOT EXISTS network-traffic-source WITH (
+CREATE SOURCE CONNECTOR IF NOT EXISTS network_traffic_source WITH (
   'connector.class'   = 'RabbitMQSource',
-  'name'              = 'network-traffic-source',
+  'name'              = 'network_traffic_source',
   'kafka.api.key'     = '<my-kafka-api-key>',
   'kafka.api.secret'  = '<my-kafka-api-secret>',
   'kafka.topic'       = 'network-traffic',

--- a/_includes/tutorials/location-based-alerting/confluent/code/tutorial-steps/dev/sink.sql
+++ b/_includes/tutorials/location-based-alerting/confluent/code/tutorial-steps/dev/sink.sql
@@ -1,6 +1,6 @@
-CREATE SINK CONNECTOR IF NOT EXISTS promo-alerts-sink WITH (
+CREATE SINK CONNECTOR IF NOT EXISTS promo_alerts_sink WITH (
   'connector.class'    = 'ElasticsearchSink',
-  'name'               = 'promo-alerts-sink',
+  'name'               = 'promo_alerts_sink',
   'input.data.format'  = 'JSON',
   'kafka.api.key'      = '<my-kafka-api-key>',
   'kafka.api.secret'   = '<my-kafka-api-secret>',

--- a/_includes/tutorials/location-based-alerting/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/location-based-alerting/confluent/code/tutorial-steps/dev/source.sql
@@ -1,6 +1,6 @@
 CREATE SOURCE CONNECTOR IF NOT EXISTS merchant_data_cdc WITH (
   'connector.class'       = 'PostgresSource',
-  'name'                  = 'merchant-data-source',
+  'name'                  = 'merchant_data_cdc',
   'kafka.api.key'         = '<my-kafka-api-key>',
   'kafka.api.secret'      = '<my-kafka-api-secret>',
   'connection.host'       = '<database-host>',

--- a/_includes/tutorials/location-based-alerting/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/location-based-alerting/confluent/code/tutorial-steps/dev/source.sql
@@ -1,4 +1,4 @@
-CREATE SOURCE CONNECTOR IF NOT EXISTS merchant-data-cdc WITH (
+CREATE SOURCE CONNECTOR IF NOT EXISTS merchant_data_cdc WITH (
   'connector.class'       = 'PostgresSource',
   'name'                  = 'merchant-data-source',
   'kafka.api.key'         = '<my-kafka-api-key>',

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.sql
@@ -1,4 +1,4 @@
-CREATE SINK CONNECTOR IF NOT EXISTS training-data WITH (
+CREATE SINK CONNECTOR IF NOT EXISTS training_data WITH (
     'connector.class'          = 'MongoDbAtlasSink',
     'name'                     = 'weight-data', 
     'kafka.auth.mode'          = 'KAFKA_API_KEY',
@@ -13,11 +13,11 @@ CREATE SINK CONNECTOR IF NOT EXISTS training-data WITH (
     'retries.defer.timeout'    = '5000',
     'max.batch.size'           = '0',
     'database'                 = 'mdb',
-    'collection'               = 'training-data',
+    'collection'               = 'training_data',
     'tasks.max'                = '1'
 );     
 
-CREATE SINK CONNECTOR IF NOT EXISTS retraining-trigger WITH (
+CREATE SINK CONNECTOR IF NOT EXISTS retraining_trigger WITH (
     'connector.class'          = 'HttpSink',
     'input.data.format'        = 'JSON',
     'name'                     = 'retrain-trigger',

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.sql
@@ -1,7 +1,7 @@
 -- Stream of fish weight predictions
-CREATE SOURCE CONNECTOR IF NOT EXISTS weight-predictions WITH (
+CREATE SOURCE CONNECTOR IF NOT EXISTS weight_predictions WITH (
   'connector.class'        = 'MongoDbAtlasSource',
-  'name'                   = 'model-retrain-weight-predictions',
+  'name'                   = 'model-retrain-weight_predictions',
   'kafka.api.key'          = '<my-kafka-api-key>',
   'kafka.api.secret'       = '<my-kafka-api-secret>',
   'connection.host'        = '<database-host-address>',
@@ -18,9 +18,9 @@ CREATE SOURCE CONNECTOR IF NOT EXISTS weight-predictions WITH (
 );
 
 -- Stream of actual fish weights
-CREATE SOURCE CONNECTOR IF NOT EXISTS actual-weights WITH (
+CREATE SOURCE CONNECTOR IF NOT EXISTS actual_weights WITH (
   'connector.class'        = 'MongoDbAtlasSource',
-  'name'                   = 'model-retrain-actual-weights',
+  'name'                   = 'model-retrain-actual_weights',
   'kafka.api.key'          = '<my-kafka-api-key>',
   'kafka.api.secret'       = '<my-kafka-api-secret>',
   'connection.host'        = '<database-host-address>',

--- a/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/model-retraining/confluent/code/tutorial-steps/dev/source.sql
@@ -1,7 +1,7 @@
 -- Stream of fish weight predictions
 CREATE SOURCE CONNECTOR IF NOT EXISTS weight_predictions WITH (
   'connector.class'        = 'MongoDbAtlasSource',
-  'name'                   = 'model-retrain-weight_predictions',
+  'name'                   = 'model-retrain-weight-predictions',
   'kafka.api.key'          = '<my-kafka-api-key>',
   'kafka.api.secret'       = '<my-kafka-api-secret>',
   'connection.host'        = '<database-host-address>',
@@ -20,7 +20,7 @@ CREATE SOURCE CONNECTOR IF NOT EXISTS weight_predictions WITH (
 -- Stream of actual fish weights
 CREATE SOURCE CONNECTOR IF NOT EXISTS actual_weights WITH (
   'connector.class'        = 'MongoDbAtlasSource',
-  'name'                   = 'model-retrain-actual_weights',
+  'name'                   = 'model-retrain-actual-weights',
   'kafka.api.key'          = '<my-kafka-api-key>',
   'kafka.api.secret'       = '<my-kafka-api-secret>',
   'connection.host'        = '<database-host-address>',

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -35,7 +35,7 @@
     <div class="hero-body">
       <div class="container">
         <ul class="breadcrumb">
-          <li><a href="{{ "/index.html" | relative_url }}">&lt; Back to recipes</a></li>
+          <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
         </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -35,7 +35,7 @@
     <div class="hero-body">
       <div class="container">
         <ul class="breadcrumb">
-          <li><a href="{{ "/use-cases.html" | relative_url }}">&lt; Back to tutorials</a></li>
+          <li><a href="{{ "/index.html" | relative_url }}">&lt; Back to recipes</a></li>
         </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -127,7 +127,7 @@
       <section class="section">
         <div class="container">
           <ul class="breadcrumb">
-            <li><a href="{{ "/use-cases.html" | relative_url }}">&lt; Back to tutorials</a></li>
+            <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
           </ul>
         </div>
       </section>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -36,7 +36,7 @@
     <div class="hero-body">
       <div class="container">
         <ul class="breadcrumb">
-          <li><a href="{{ "/index.html" | relative_url }}">&lt; Back to tutorials</a></li>
+          <li><a href="{{ "/index.html" | relative_url }}">&lt; Back to recipes</a></li>
         </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -36,7 +36,7 @@
     <div class="hero-body">
       <div class="container">
         <ul class="breadcrumb">
-          <li><a href="{{ "/index.html" | relative_url }}">&lt; Back to recipes</a></li>
+          <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
         </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -266,7 +266,7 @@
       <section class="section">
         <div class="container">
           <ul class="breadcrumb">
-            <li><a href="{{ "/index.html" | relative_url }}">&lt; Back to tutorials</a></li>
+            <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
           </ul>
         </div>
       </section>


### PR DESCRIPTION
### Description

#1213 
#1214 

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/fix-issues

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
