### PR TITLE
chore: try different jfrog secret

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,9 +14,11 @@ global_job_config:
       - . vault-bin/vault-setup
       - . vault-sem-get-secret aws_credentials
       - . vault-sem-get-secret dockerhub-semaphore-cred
+      - . vault-sem-get-secret artifactory-docker-helm
       - >
         aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
       - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+      - docker login --username $DOCKER_USER --password $DOCKER_APIKEY confluent-docker.jfrog.io
       - sudo pip3 install -e harness_runner/
       - >
         find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}


### PR DESCRIPTION
### Description
This cherry-picks the PR that updates semaphore config so that jfrog-based images can be used in CI. The commit was pushed to the `ksqldb-latest` but didn't exist in `master`. We are updating this to follow the approach outline by @colinhicks [here](https://github.com/confluentinc/kafka-tutorials/pull/1228#pullrequestreview-935172768) for the kafka-tutorials tests. 