### PR TITLE
cleaning up tutorial hero: moving launch button and breadcrumb

### DIFF
--- a/_includes/recipe-content-answer.html
+++ b/_includes/recipe-content-answer.html
@@ -1,29 +1,21 @@
-<div>
+<div class="launch-container">
 
    {% if site.data.harnesses[page.static_data][page.stack].answer %}
 
-   <br>
-   <br>
-   <br>
-   <br>
-
-     <div class="container" style="background-color: #E6F5FB; padding: 30px; ">
-       <div class="columns">
-         <div class="column is-full">
-           <h3 class="title">Launch recipe in Confluent Cloud</h3>
            {% for step in site.data.harnesses[page.static_data][page.stack].answer.steps %}
 
             <div class="tutorial-try-it-step content">
+            {% if step.title %}
              <h4 class="subtitle" id="{{ step.title | slugify }}">
-               <div class="text">{{ step.title }}</div>
+               <div class="text">{{ step.title }} Fake Title</div>
              </h4>
-
+             {% endif %}
               {% for section in step.content %}
 
               {% if section.render.skip != true %}
 
         <div class="ctas">
-          <a href="https://www.confluent.io/confluent-cloud/tryfree/\?next=tutorials/ksql-recipe-{{ page.static_data }}" class="btn-denim">Launch</a>
+          <a href="https://www.confluent.io/confluent-cloud/tryfree/\?next=tutorials/ksql-recipe-{{ page.static_data }}" class="btn-island">Launch recipe in Confluent Cloud</a>
         </div>
 
               {% endif %}
@@ -31,9 +23,6 @@
               {% endfor %}
            </div>
            {% endfor %}
-         </div>
-       </div>
-     </div>
    {% endif %}
 
 </div>

--- a/_includes/recipe-content-answer.html
+++ b/_includes/recipe-content-answer.html
@@ -6,10 +6,10 @@
 
             <div class="tutorial-try-it-step content">
             {% if step.title %}
-             <h4 class="subtitle" id="{{ step.title | slugify }}">
-               <div class="text">{{ step.title }}</div>
-             </h4>
-             {% endif %}
+              <h4 class="subtitle" id="{{ step.title | slugify }}">
+                <div class="text">{{ step.title }}</div>
+              </h4>
+            {% endif %}
               {% for section in step.content %}
 
               {% if section.render.skip != true %}

--- a/_includes/recipe-content-answer.html
+++ b/_includes/recipe-content-answer.html
@@ -7,7 +7,7 @@
             <div class="tutorial-try-it-step content">
             {% if step.title %}
              <h4 class="subtitle" id="{{ step.title | slugify }}">
-               <div class="text">{{ step.title }} Fake Title</div>
+               <div class="text">{{ step.title }}</div>
              </h4>
              {% endif %}
               {% for section in step.content %}

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -34,21 +34,25 @@
   <section class="hero">
     <div class="hero-body">
       <div class="container">
-        <ul class="breadcrumb">
-          <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
-        </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>
         {% endif %}
         <div class="headline">
           <h1>{{ site.data.tutorials[page.static_data].title }}</h1>
         </div>
+
+        {% unless page.help_wanted %}
+        {% include recipe-content-answer.html %}
+        {% endunless %}
       </div>
     </div>
   </section>
 
   <section class="section">
     <div class="container">
+      <ul class="breadcrumb">
+        <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
+      </ul>
       <a href="{{ site.github_url }}/tree/master/_includes/tutorials/{{ page.static_data }}" class="btn-edit"><img src="{{ "/assets/img/icon-edit.svg" | relative_url }}" alt="Edit this page" /></a>
       {% unless page.help_wanted %}
         <div class="example">
@@ -60,12 +64,6 @@
           </div>
         </div>
       {% endunless %}
-
-      <div class="tutorial-markup">
-        {% unless page.help_wanted %}
-        {% include recipe-content-answer.html %}
-        {% endunless %}
-      </div>
 
       {% if site.data.harnesses[page.static_data][page.stack].dev %}
       <div class="columns">

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -50,6 +50,9 @@
 
   <section class="section">
     <div class="container">
+      {% if site.data.tutorials[page.static_data].introduction-media %}
+        <img class="example-image" src="{{ site.data.tutorials[page.static_data].introduction-media | relative_url }}" />
+      {% endif %}
       <ul class="breadcrumb">
         <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
       </ul>
@@ -66,8 +69,8 @@
       {% endunless %}
 
       {% if site.data.harnesses[page.static_data][page.stack].dev %}
-      <div class="columns">
-        <div class="column is-5">
+      <div class="columns" {% if page.media_youtube %}style="clear: both;"{% endif %}>
+        <div {% if page.media_youtube %}class="column is-5"{% else %}class="column">{% endif %}
           <ul id="toc" class="tutorial-navigation">
             <li><a href="#run-it">Run it</a></li>
             <ul>
@@ -101,14 +104,14 @@
             {% endif %}
           </ul>
         </div>
-        <div class="column is-7 tutorial-media-container">
-          {% if page.media_youtube %}
-          <h5 class="title is-5">Video walkthrough</h5>
-           <figure class="image">
+        {% if page.media_youtube %}
+          <div class="column is-7 tutorial-media-container">
+            <h5 class="title is-5">Video walkthrough</h5>
+            <figure class="image">
               <iframe src="https://www.youtube.com/embed/{{ page.media_youtube }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             </figure>
-          {% endif %}
-        </div>
+          </div>
+        {% endif %}
       </div>
       {% endif %}
     </div>

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -34,6 +34,9 @@
   <section class="hero">
     <div class="hero-body">
       <div class="container">
+        <ul class="breadcrumb">
+          <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
+        </ul>
         {% if page.community_contribution %}
         <span class="community-contribution">Community contribution ✨</span>
         {% endif %}
@@ -53,9 +56,6 @@
       {% if site.data.tutorials[page.static_data].introduction-media %}
         <img class="example-image" src="{{ site.data.tutorials[page.static_data].introduction-media | relative_url }}" />
       {% endif %}
-      <ul class="breadcrumb">
-        <li><a href="{{ "/" | relative_url }}">&lt; Back to recipes</a></li>
-      </ul>
       <a href="{{ site.github_url }}/tree/master/_includes/tutorials/{{ page.static_data }}" class="btn-edit"><img src="{{ "/assets/img/icon-edit.svg" | relative_url }}" alt="Edit this page" /></a>
       {% unless page.help_wanted %}
         <div class="example">

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -54,6 +54,9 @@
 
   <section class="section">
     <div class="container">
+      {% if site.data.tutorials[page.static_data].introduction-media %}
+        <img class="example-image" src="{{ site.data.tutorials[page.static_data].introduction-media | relative_url }}" />
+      {% endif %}
       <a href="{{ site.github_url }}/tree/master/_includes/tutorials/{{ page.static_data }}" class="btn-edit"><img src="{{ "/assets/img/icon-edit.svg" | relative_url }}" alt="Edit this page" /></a>
       {% unless page.help_wanted %}
         <div class="example">

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -257,7 +257,7 @@ a {
   }
 
   .container {
-    margin: 15px 0;
+    margin: 15px auto;
 
     .title {
       color: #E6F5FB;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -256,6 +256,14 @@ a {
     }
   }
 
+  .container {
+    margin: 15px 0;
+
+    .title {
+      color: #E6F5FB;
+    }
+  }
+
   .footer {
     margin-top: 130px;
   }
@@ -417,6 +425,8 @@ a {
 .section {
   .container {
     .breadcrumb {
+      margin-top: 0;
+      
       a {
         color: $color_black !important;
         font-weight: 900;

--- a/assets/sass/tutorial.scss
+++ b/assets/sass/tutorial.scss
@@ -65,6 +65,17 @@
         margin: 20px auto;
       }
 
+      .launch-container {
+        padding: 0;
+
+        .tutorial-try-it-step {
+          .subtitle {
+            color: $color_white;
+            margin-left: 0;
+          }
+        }
+      }
+
       .community-contribution {
         font-size: 0.75rem;
         background: $color_white;

--- a/assets/sass/tutorial.scss
+++ b/assets/sass/tutorial.scss
@@ -19,6 +19,17 @@
       font-size: 28px;
       margin-top: 40px;
     }
+
+    .example-image {
+      float: right;
+      margin-left: 25px;
+      width: 436px;
+      height: 100%;
+
+      @include for-max-mobile {
+        display: none;
+      }
+    }
   }
 
   .btn-edit {
@@ -49,6 +60,10 @@
 
   .tutorial-try-it-step p {
     @include p;
+  }
+
+  .tutorial-markup .section:first-of-type {
+    padding-top: 0;
   }
 
   .hero {
@@ -104,8 +119,10 @@
         flex-direction: column;
 
         .image {
+          display: inline-block;
           margin-left: 0;
           width: 100%;
+          height: 100%;
         }
       }
     }
@@ -116,10 +133,7 @@
     }
 
     .image {
-      display: inline-block;
-      margin-left: 25px;
-      width: 436px;
-      height: 100%;
+      display: none;
     }
   }
 
@@ -167,7 +181,6 @@
   }
 
   .tutorial-navigation {
-    margin-top: 60px;
     display: inline-block;
 
     li {


### PR DESCRIPTION
### Description

Per discussions, we're cleaning up the hero and making the "Launch..." button more prominent.

<img width="1260" alt="Screen Shot 2022-04-14 at 1 26 39 PM" src="https://user-images.githubusercontent.com/66280178/163443534-362e353e-b64f-462d-8bd1-2b7c993f301c.png">

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
