### PR TITLE
Reorder ksqlDB commands so INSERT option presented before connector

### DIFF
--- a/_data/harnesses/credit-card-activity/confluent.yml
+++ b/_data/harnesses/credit-card-activity/confluent.yml
@@ -26,10 +26,6 @@ dev:
 
         - action: skip
           render:
-            file: shared/markup/ccloud/manual_insert.adoc
-
-        - action: skip
-          render:
             file: tutorials/credit-card-activity/confluent/markup/dev/ksqlDB.adoc
 
         - action: skip
@@ -40,15 +36,11 @@ dev:
           render:
             file: tutorials/credit-card-activity/confluent/markup/dev/process.adoc
 
-    - title: Test with mock data
+    - title: Test with real data
       content:
         - action: skip
           render:
-            file: shared/markup/ccloud/manual_cue.adoc
-
-        - action: skip
-          render:
-            file: tutorials/credit-card-activity/confluent/markup/dev/manual.adoc
+            file: tutorials/credit-card-activity/confluent/markup/dev/source.adoc
 
     - title: Cleanup
       content:

--- a/_includes/shared/code/ccloud/comment-manual.sql
+++ b/_includes/shared/code/ccloud/comment-manual.sql
@@ -1,0 +1,1 @@
+-- Add the INSERT INTO commands to insert mock data into the streams

--- a/_includes/shared/markup/ccloud/connect.adoc
+++ b/_includes/shared/markup/ccloud/connect.adoc
@@ -1,2 +1,2 @@
 ksqlDB processes data in realtime, and you can also import and export data straight from ksqlDB from popular data sources and end systems in the cloud.
-This tutorial shows sample connector(s) below, but you can run another connector to any link:https://docs.confluent.io/cloud/current/connectors/index.html[supported data source].
+This tutorial shows you how to run the recipe in one of two ways: using connector(s) to any link:https://docs.confluent.io/cloud/current/connectors/index.html[supported data source] or using ksqlDB's `INSERT INTO` functionality.

--- a/_includes/tutorials/credit-card-activity/confluent/markup/dev/process.adoc
+++ b/_includes/tutorials/credit-card-activity/confluent/markup/dev/process.adoc
@@ -1,7 +1,7 @@
 ++++
 <pre class="snippet expand-default"><code class="sql">
-{% include_raw shared/code/ccloud/comment-connector.sql %}
-{% include_raw tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/source.sql %}
 {% include_raw tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/process.sql %}
+{% include_raw shared/code/ccloud/comment-manual.sql %}
+{% include_raw tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/manual.sql %}
 </code></pre>
 ++++

--- a/_includes/tutorials/credit-card-activity/confluent/markup/dev/process.adoc
+++ b/_includes/tutorials/credit-card-activity/confluent/markup/dev/process.adoc
@@ -5,3 +5,15 @@
 {% include_raw tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/manual.sql %}
 </code></pre>
 ++++
+
+To validate that this recipe is working, run the following query:
+
+++++
+<pre class="snippet"><code class="sql">{% include_raw tutorials/credit-card-activity/ksql-test/code/tutorial-steps/test/validate.sql %}</code></pre>
+++++
+
+Your output should resemble:
+
+++++
+<pre class="snippet"><code class="text">{% include_raw tutorials/credit-card-activity/ksql-test/code/tutorial-steps/test/expected-outputs/credit-card.log %}</code></pre>
+++++

--- a/_includes/tutorials/credit-card-activity/confluent/markup/dev/source.adoc
+++ b/_includes/tutorials/credit-card-activity/confluent/markup/dev/source.adoc
@@ -1,3 +1,5 @@
+If you have real end systems to connect to, adapt the sample connector configuration(s) below and run them from ksqlDB with `CREATE SOURCE CONNECTOR`.
+
 ++++
-<pre class="snippet"><code class="json">{% include_raw tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/source.json %}</code></pre>
+<pre class="snippet"><code class="sql">{% include_raw tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/source.sql %}</code></pre>
 ++++


### PR DESCRIPTION
### Description

Test one recipe with reorder INSERT INTO vs connector

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/reorder-insert/credit-card-activity/confluent.html

Compare to current presentation: https://developer.confluent.io/tutorials/credit-card-activity/confluent.html

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
