### PR TITLE
Trim model retraining recipe to upvalue downstream into the product

### DIFF
--- a/_data/harnesses/model-retraining/confluent.yml
+++ b/_data/harnesses/model-retraining/confluent.yml
@@ -32,32 +32,8 @@ dev:
           render:
             file: tutorials/model-retraining/confluent/markup/dev/ksqlDB.adoc
 
-        - action: skip
-          render:
-            file: shared/markup/ccloud/ksqldb_processing_intro.adoc
-
-        - action: skip
-          render:
-            file: tutorials/model-retraining/confluent/markup/dev/process.adoc
-
-    - title: Test with mock data
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/manual_cue.adoc
-
-        - action: skip
-          render:
-            file: tutorials/model-retraining/confluent/markup/dev/manual.adoc
-
     - title: Write the data out
       content:
         - action: skip
           render:
             file: tutorials/model-retraining/confluent/markup/dev/sink.adoc
-
-    - title: Cleanup
-      content:
-        - action: skip
-          render:
-            file: shared/markup/ccloud/cleanup.adoc

--- a/_includes/shared/markup/ccloud/ccloud_setup.adoc
+++ b/_includes/shared/markup/ccloud/ccloud_setup.adoc
@@ -1,2 +1,3 @@
 Once your Confluent Cloud cluster is available, create a link:https://ksqldb.io/[ksqlDB] application and navigate to the ksqlDB editor to execute this tutorial.
-ksqlDB supports `SQL` language for extracting, transforming, and loading events within your Kafka cluster.
+ksqlDB supports `SQL` language for real-time extracting, transforming, and loading events within your Kafka cluster.
+You can also import and export data straight from ksqlDB from popular data sources and end systems in the cloud.

--- a/_includes/shared/markup/ccloud/connect.adoc
+++ b/_includes/shared/markup/ccloud/connect.adoc
@@ -1,2 +1,2 @@
-ksqlDB processes data in realtime, and you can also import and export data straight from ksqlDB from popular data sources and end systems in the cloud.
-This tutorial shows you how to run the recipe in one of two ways: using connector(s) to any link:https://docs.confluent.io/cloud/current/connectors/index.html[supported data source] or using ksqlDB's `INSERT INTO` functionality.
+When you log into link:https://www.confluent.io/confluent-cloud/tryfree/\?next=tutorials/ksql-recipe-{{ page.static_data }}[Confluent Cloud], you'll be directed to the ksqlDB editor to try this recipe.
+You can run it in one of two ways: using connector(s) to any link:https://docs.confluent.io/cloud/current/connectors/index.html[supported data source] or using ksqlDB's `INSERT INTO` functionality.

--- a/_includes/shared/markup/ccloud/manual_insert.adoc
+++ b/_includes/shared/markup/ccloud/manual_insert.adoc
@@ -1,1 +1,1 @@
-If you cannot connect to a real data source with properly formatted data, or if you just want to execute this tutorial without external dependencies, no worries! Remove the `CREATE SOURCE CONNECTOR` commands and link:#test-with-mock-data[insert mock data] into the streams.
+If you cannot connect to a real data source with properly formatted data, or if you just want to execute this tutorial without external dependencies, no worries! Remove the `CREATE SOURCE CONNECTOR` commands and insert mock data into the streams.

--- a/_includes/shared/markup/ccloud/manual_insert_no_connector.adoc
+++ b/_includes/shared/markup/ccloud/manual_insert_no_connector.adoc
@@ -1,1 +1,1 @@
-If you cannot connect to a real data source with properly formatted data, or if you just want to execute this tutorial without external dependencies, no worries! After you create the ksqlDB application, link:#test-with-mock-data[insert mock data] into the streams.
+If you cannot connect to a real data source with properly formatted data, or if you just want to execute this tutorial without external dependencies, no worries! After you create the ksqlDB application, insert mock data into the streams.

--- a/_includes/tutorials/model-retraining/confluent/markup/dev/sink.adoc
+++ b/_includes/tutorials/model-retraining/confluent/markup/dev/sink.adoc
@@ -1,5 +1,1 @@
-Now we'll use a MongoDB sink connector to send the combined predictions and actual weights to a database, and the HTTP sink connector to trigger the retraining process.
-
-++++
-<pre class="snippet"><code class="sql">{% include_raw tutorials/model-retraining/confluent/code/tutorial-steps/dev/sink.sql %}</code></pre>
-++++
+Then use any sink connector, for example this recipe uses a link:https://docs.confluent.io/cloud/current/connectors/cc-mongo-db-sink.html#step-3-create-the-connector-configuration-file[MongoDB Atlas Sink Connector], to send the combined predictions and actual weights to a database, and a link:https://docs.confluent.io/cloud/current/connectors/cc-http-sink.html[HTTP Sink Connector] to trigger the retraining process.


### PR DESCRIPTION
### Description

Trim recipe to upvalue downstream into the product

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/trim-recipe-test/model-retraining/confluent.html

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
