### PR TITLE
KSE-1028: fix duplicate parameter

### DIFF
--- a/_includes/tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/source.json
+++ b/_includes/tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/source.json
@@ -1,7 +1,6 @@
 {
   "connector.class"          : "OracleDatabaseSource",
   "name"                     : "recipe-oracle-transactions-cc",
-  "connector.class"          : "OracleDatabaseSource",
   "kafka.api.key"            : "<my-kafka-api-key>",
   "kafka.api.secret"         : "<my-kafka-api-secret>",
   "connection.host"          : "<database-host>",
@@ -19,7 +18,6 @@
 {
   "connector.class"          : "OracleDatabaseSource",
   "name"                     : "recipe-oracle-customers-cc",
-  "connector.class"          : "OracleDatabaseSource",
   "kafka.api.key"            : "<my-kafka-api-key>",
   "kafka.api.secret"         : "<my-kafka-api-secret>",
   "connection.host"          : "<database-host>",

--- a/_includes/tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/credit-card-activity/confluent/code/tutorial-steps/dev/source.sql
@@ -2,7 +2,6 @@
 CREATE SOURCE CONNECTOR IF NOT EXISTS FD_transactions WITH (
   'connector.class'          = 'OracleDatabaseSource',
   'name'                     = 'recipe-oracle-transactions-cc',
-  'connector.class'          = 'OracleDatabaseSource',
   'kafka.api.key'            = '<my-kafka-api-key>',
   'kafka.api.secret'         = '<my-kafka-api-secret>',
   'connection.host'          = '<database-host>',
@@ -21,7 +20,6 @@ CREATE SOURCE CONNECTOR IF NOT EXISTS FD_transactions WITH (
 CREATE SOURCE CONNECTOR IF NOT EXISTS FD_customers WITH (
   'connector.class'          = 'OracleDatabaseSource',
   'name'                     = 'recipe-oracle-customers-cc',
-  'connector.class'          = 'OracleDatabaseSource',
   'kafka.api.key'            = '<my-kafka-api-key>',
   'kafka.api.secret'         = '<my-kafka-api-secret>',
   'connection.host'          = '<database-host>',

--- a/_includes/tutorials/denormalization/confluent/code/tutorial-steps/dev/source.json
+++ b/_includes/tutorials/denormalization/confluent/code/tutorial-steps/dev/source.json
@@ -18,7 +18,6 @@
 {
   "connector.class"          : "OracleDatabaseSource",
   "name"                     : "recipe-oracle-customers",
-  "connector.class"          : "OracleDatabaseSource",
   "kafka.api.key"            : "<my-kafka-api-key>",
   "kafka.api.secret"         : "<my-kafka-api-secret>",
   "topic.prefix"             : "oracle_",

--- a/_includes/tutorials/denormalization/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/denormalization/confluent/code/tutorial-steps/dev/source.sql
@@ -20,7 +20,6 @@ CREATE SOURCE CONNECTOR IF NOT EXISTS sales_orders WITH (
 CREATE SOURCE CONNECTOR IF NOT EXISTS customers WITH (
   'connector.class'          = 'OracleDatabaseSource',
   'name'                     = 'recipe-oracle-customers',
-  'connector.class'          = 'OracleDatabaseSource',
   'kafka.api.key'            = '<my-kafka-api-key>',
   'kafka.api.secret'         = '<my-kafka-api-secret>',
   'topic.prefix'             = 'oracle_',


### PR DESCRIPTION
### Description

https://confluentinc.atlassian.net/browse/KSE-1028

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
