### PR TITLE
adding swiftype meta tags for tutorials and recipes

### DIFF
--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -8,6 +8,9 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta class="swiftype" name="site-id" data-type="integer" content="3" />
+  <meta class="swiftype" name="docs-boost" data-type="integer" content="6" />
+  <meta class="swiftype" name="category" data-type="string" content="recipe" />
   <meta name="description" content="In this tutorial, learn how to {{ site.data.tutorials[page.static_data].meta-description }} using {{ site.data.stacks[page.stack].pretty }}, with step-by-step instructions and examples.">
   {% if site.data.tutorials[page.static_data].canonical %}
     {% unless page.stack == site.data.tutorials[page.static_data].canonical or page.stack == 'ksql' %}

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -8,6 +8,9 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta class="swiftype" name="site-id" data-type="integer" content="3" />
+  <meta class="swiftype" name="docs-boost" data-type="integer" content="6" />
+  <meta class="swiftype" name="category" data-type="string" content="tutorial" />
   <meta name="description" content="In this tutorial, learn how to {{ site.data.tutorials[page.static_data].meta-description }} using {{ site.data.stacks[page.stack].pretty }}, with step-by-step instructions and examples.">
   {% if site.data.tutorials[page.static_data].canonical %}
     {% unless page.stack == site.data.tutorials[page.static_data].canonical or page.stack == 'ksql' %}


### PR DESCRIPTION
### Description

The swiftype tags are missing for tutorials and recipes. Adding those and a `category` tag for the new developer search https://app.asana.com/0/1178383736931373/1156641992335726