### PR TITLE
Changes for updating tutorials to work with AK 3.1

### DIFF
--- a/_data/harnesses/error-handling/confluent.yml
+++ b/_data/harnesses/error-handling/confluent.yml
@@ -73,6 +73,11 @@ dev:
           render:
             file: tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc
 
+        - action: make_file
+          file: src/main/java/io/confluent/developer/ProcessorException.java
+          render:
+            skip: true    
+
     - title: Create the Kafka Streams topology
       content:
         - action: make_file

--- a/_data/harnesses/error-handling/kstreams.yml
+++ b/_data/harnesses/error-handling/kstreams.yml
@@ -64,7 +64,12 @@ dev:
         - action: make_file
           file: src/main/java/io/confluent/developer/MaxFailuresUncaughtExceptionHandler.java
           render:
-            file: tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc      
+            file: tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc
+
+        - action: make_file
+          file: src/main/java/io/confluent/developer/ProcessorException.java
+          render:
+            skip: true          
          
     - title: Create the Kafka Streams topology
       content:
@@ -95,7 +100,7 @@ dev:
 
         - name: wait for the consumer to read the messages
           action: sleep
-          ms: 30000
+          ms: 60000
           render:
             skip: true
 

--- a/_data/harnesses/naming-changelog-repartition-topics/kstreams.yml
+++ b/_data/harnesses/naming-changelog-repartition-topics/kstreams.yml
@@ -106,7 +106,7 @@ dev:
 
         - name: wait for streams to stop
           action: sleep
-          ms: 5000
+          ms: 10000
           render:
             skip: true    
      
@@ -114,6 +114,12 @@ dev:
           file: tutorial-steps/dev/run-dev-app-no-name-filter.sh
           render:
             skip: true
+
+        - name: wait for updated streams app to create new changelogs
+          action: sleep
+          ms: 60000
+          render:
+            skip: true    
 
     - title: Produce some records to the updated topology
       content:
@@ -160,6 +166,12 @@ dev:
           render:
             skip: true
 
+        - name: wait for updated streams app to create new changelogs
+          action: sleep
+          ms: 60000
+          render:
+            skip: true  
+
     - title: Produce records to the named topology
       content:
         - action: execute
@@ -203,6 +215,12 @@ dev:
           file: tutorial-steps/dev/run-dev-app-names-with-filter.sh
           render:
             skip: true
+            
+        - name: wait for updated streams app to create new changelogs
+          action: sleep
+          ms: 60000
+          render:
+            skip: true  
 
     - title: Produce records to the updated, named topology
       content:

--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -33,10 +33,10 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.0"
     implementation "org.slf4j:slf4j-simple:1.7.36"
-    implementation "org.apache.kafka:kafka-streams:2.8.1"
-    implementation "org.apache.kafka:kafka-clients:2.8.1"
+    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "org.apache.kafka:kafka-clients:3.1.0"
     
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:2.8.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/error-handling/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/error-handling/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/ProcessorException.java
+++ b/_includes/tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/ProcessorException.java
@@ -1,0 +1,8 @@
+package io.confluent.developer;
+
+public class ProcessorException extends RuntimeException {
+
+    public ProcessorException(String message) {
+        super(message);
+    }
+}

--- a/_includes/tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/StreamsUncaughtExceptionHandling.java
+++ b/_includes/tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/StreamsUncaughtExceptionHandling.java
@@ -17,11 +17,10 @@ import org.apache.kafka.streams.kstream.Produced;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 public class StreamsUncaughtExceptionHandling {
@@ -37,7 +36,7 @@ public class StreamsUncaughtExceptionHandling {
                 .mapValues(value -> {
                     counter++;
                     if (counter == 2 || counter == 8 || counter == 15) {
-                        throw new IllegalStateException("It works on my box!!!");
+                        throw new ProcessorException("It works on my box!!!");
                     }
                     return value.toUpperCase();
                 })
@@ -102,7 +101,7 @@ public class StreamsUncaughtExceptionHandling {
         Runtime.getRuntime().addShutdownHook(new Thread("streams-shutdown-hook") {
             @Override
             public void run() {
-                streams.close();
+                streams.close(Duration.ofSeconds(5));
             }
         });
 

--- a/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/console-consumer.sh
@@ -1,6 +1,6 @@
-docker-compose exec broker kafka-console-consumer \
+docker-compose exec -T broker kafka-console-consumer \
  --bootstrap-server broker:9092 \
  --topic output-topic \
  --from-beginning \
- --max-messages 12
+ --max-messages 6
 

--- a/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec -T broker kafka-console-consumer \
+docker-compose exec broker kafka-console-consumer \
  --bootstrap-server broker:9092 \
  --topic output-topic \
  --from-beginning \

--- a/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/expected-output.txt
+++ b/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/expected-output.txt
@@ -4,10 +4,4 @@ STREAMS
 LEAD
 TO
 CONFLUENT
-ALL
-STREAMS
-LEAD
-TO
-CONFLUENT
-GO
-Processed a total of 12 messages
+Processed a total of 6 messages

--- a/_includes/tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc
+++ b/_includes/tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc
@@ -65,4 +65,10 @@ Now create the following file at `src/main/java/io/confluent/developer/MaxFailur
 
 You'll add the `StreamsUncaughtExceptionHandler` to your Kafka Streams application in the next step.
 
+There's one more step you'll need to take and that is creating a custom exception class `ProcessorException` that your exception handler will process. Create this simple Java class at `src/main/java/io/confluent/developer/ProcessorException.java`
+
++++++
+<pre class="snippet"><code class="java">{% include_raw tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/ProcessorException.java %}</code></pre>
++++++
+
 NOTE: There is an older, deprecated version of https://kafka.apache.org/28/javadoc/org/apache/kafka/streams/KafkaStreams.html#setUncaughtExceptionHandler-java.lang.Thread.UncaughtExceptionHandler-[KafkaStreams.setUncaughtExceptionHandler] that takes an instance of a `java.lang.Thread.UncaughtExceptionHandler`.  It is advised for users to migrate to use the newer method.

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/.gitignore
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/.gitignore
@@ -1,0 +1,1 @@
+tutorial-steps/dev/outputs

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -33,9 +33,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.0"
     implementation "org.slf4j:slf4j-simple:1.7.36"
-    implementation "org.apache.kafka:kafka-streams:2.8.1"
-    implementation "io.confluent:kafka-streams-avro-serde:6.2.1"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:2.8.1"
+    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.1.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.1.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:6.2.1
+    image: confluentinc/cp-schema-registry:7.1.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/src/main/java/io/confluent/developer/NamingChangelogAndRepartitionTopics.java
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/src/main/java/io/confluent/developer/NamingChangelogAndRepartitionTopics.java
@@ -2,15 +2,6 @@ package io.confluent.developer;
 
 
 import io.confluent.common.utils.TestUtils;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.serialization.Serde;
@@ -27,6 +18,16 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.StreamJoined;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 
 public class NamingChangelogAndRepartitionTopics {
 

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/src/main/java/io/confluent/developer/NamingChangelogAndRepartitionTopics.java
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/src/main/java/io/confluent/developer/NamingChangelogAndRepartitionTopics.java
@@ -70,7 +70,7 @@ public class NamingChangelogAndRepartitionTopics {
                                     .toStream();
 
         joinedStream = inputStream.join(countStream, (v1, v2) -> v1 + v2.toString(),
-                                                              JoinWindows.of(Duration.ofMillis(100)),
+                                                              JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(100)),
                                                               StreamJoined.with(longSerde, stringSerde, longSerde));
     } else {
         countStream = inputStream.groupByKey(Grouped.with("count", longSerde, stringSerde))
@@ -78,7 +78,7 @@ public class NamingChangelogAndRepartitionTopics {
                                    .toStream();
 
         joinedStream = inputStream.join(countStream, (v1, v2) -> v1 + v2.toString(),
-                                                              JoinWindows.of(Duration.ofMillis(100)),
+                                                              JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(100)),
                                                               StreamJoined.with(longSerde, stringSerde, longSerde)
                                                                           .withName("join").withStoreName("the-join-store"));
     }


### PR DESCRIPTION
### Description

covers the `Error Handling`  and `Naming Stateful Operations` tutorial for https://github.com/confluentinc/kafka-tutorials/issues/1256

### Staging Docs

Only the `Error Handling` tutorial had site updates so it's the only one listed, `Naming Stateful Operations` had internal changes only

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/Update_error_handling_to_latest_AK/ 
http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/Update_error_handling_to_latest_AK/error-handling/kstreams.html

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
