### PR TITLE
Kafka Tutorials Release [May 11, 2022] 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # See go/codeowners - automatically generated for confluentinc/kafka-tutorials:
-*	@confluentinc/devx
+*	@confluentinc/devx @colinhicks

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -81,8 +81,8 @@ blocks:
     task:
       prologue:
         commands:
-          - sudo apt-get install gradle-6.8.3 -y
-          - sudo update-alternatives --set gradle /usr/lib/gradle/6.8.3/bin/gradle          
+          - sudo apt-get install gradle-7.4.2 -y
+          - sudo update-alternatives --set gradle /usr/lib/gradle/7.4.2/bin/gradle          
       jobs:
         - name: KStreams Test Streams schedule operations tests
           commands:

--- a/_data/harnesses/error-handling/confluent.yml
+++ b/_data/harnesses/error-handling/confluent.yml
@@ -73,6 +73,11 @@ dev:
           render:
             file: tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc
 
+        - action: make_file
+          file: src/main/java/io/confluent/developer/ProcessorException.java
+          render:
+            skip: true    
+
     - title: Create the Kafka Streams topology
       content:
         - action: make_file

--- a/_data/harnesses/error-handling/kstreams.yml
+++ b/_data/harnesses/error-handling/kstreams.yml
@@ -64,7 +64,12 @@ dev:
         - action: make_file
           file: src/main/java/io/confluent/developer/MaxFailuresUncaughtExceptionHandler.java
           render:
-            file: tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc      
+            file: tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc
+
+        - action: make_file
+          file: src/main/java/io/confluent/developer/ProcessorException.java
+          render:
+            skip: true          
          
     - title: Create the Kafka Streams topology
       content:
@@ -95,7 +100,7 @@ dev:
 
         - name: wait for the consumer to read the messages
           action: sleep
-          ms: 30000
+          ms: 60000
           render:
             skip: true
 

--- a/_data/harnesses/messaging-modernization/confluent.yml
+++ b/_data/harnesses/messaging-modernization/confluent.yml
@@ -26,10 +26,6 @@ dev:
 
         - action: skip
           render:
-            file: shared/markup/ccloud/manual_insert.adoc
-
-        - action: skip
-          render:
             file: tutorials/messaging-modernization/confluent/markup/dev/ksqlDB.adoc
 
         - action: skip
@@ -40,15 +36,11 @@ dev:
           render:
             file: tutorials/messaging-modernization/confluent/markup/dev/process.adoc
 
-    - title: Test with mock data
+    - title: Test with real data
       content:
         - action: skip
           render:
-            file: shared/markup/ccloud/manual_cue.adoc
-
-        - action: skip
-          render:
-            file: tutorials/messaging-modernization/confluent/markup/dev/manual.adoc
+            file: tutorials/messaging-modernization/confluent/markup/dev/source.adoc
 
     - title: Cleanup
       content:

--- a/_data/harnesses/naming-changelog-repartition-topics/kstreams.yml
+++ b/_data/harnesses/naming-changelog-repartition-topics/kstreams.yml
@@ -106,7 +106,7 @@ dev:
 
         - name: wait for streams to stop
           action: sleep
-          ms: 5000
+          ms: 10000
           render:
             skip: true    
      
@@ -114,6 +114,12 @@ dev:
           file: tutorial-steps/dev/run-dev-app-no-name-filter.sh
           render:
             skip: true
+
+        - name: wait for updated streams app to create new changelogs
+          action: sleep
+          ms: 60000
+          render:
+            skip: true    
 
     - title: Produce some records to the updated topology
       content:
@@ -160,6 +166,12 @@ dev:
           render:
             skip: true
 
+        - name: wait for updated streams app to create new changelogs
+          action: sleep
+          ms: 60000
+          render:
+            skip: true  
+
     - title: Produce records to the named topology
       content:
         - action: execute
@@ -203,6 +215,12 @@ dev:
           file: tutorial-steps/dev/run-dev-app-names-with-filter.sh
           render:
             skip: true
+            
+        - name: wait for updated streams app to create new changelogs
+          action: sleep
+          ms: 60000
+          render:
+            skip: true  
 
     - title: Produce records to the updated, named topology
       content:

--- a/_data/harnesses/online-dating/confluent.yml
+++ b/_data/harnesses/online-dating/confluent.yml
@@ -26,10 +26,6 @@ dev:
 
         - action: skip
           render:
-            file: shared/markup/ccloud/manual_insert.adoc
-
-        - action: skip
-          render:
             file: tutorials/online-dating/confluent/markup/dev/ksqlDB.adoc
 
         - action: skip
@@ -40,15 +36,11 @@ dev:
           render:
             file: tutorials/online-dating/confluent/markup/dev/process.adoc
 
-    - title: Test with mock data
+    - title: Test with real data
       content:
         - action: skip
           render:
-            file: shared/markup/ccloud/manual_cue.adoc
-
-        - action: skip
-          render:
-            file: tutorials/online-dating/confluent/markup/dev/manual.adoc
+            file: tutorials/online-dating/confluent/markup/dev/source.adoc
 
     - title: Explanation
       content:

--- a/_includes/shared/code/ccloud/comment-manual.sql
+++ b/_includes/shared/code/ccloud/comment-manual.sql
@@ -1,1 +1,1 @@
--- Add the INSERT INTO commands to insert mock data into the streams
+-- Add the INSERT INTO commands to insert mock data

--- a/_includes/shared/markup/ccloud/connect.adoc
+++ b/_includes/shared/markup/ccloud/connect.adoc
@@ -1,2 +1,2 @@
 ksqlDB processes data in realtime, and you can also import and export data straight from ksqlDB from popular data sources and end systems in the cloud.
-This tutorial shows you how to run the recipe in one of two ways: using connector(s) to any link:https://docs.confluent.io/cloud/current/connectors/index.html[supported data source] or using ksqlDB's `INSERT INTO` functionality.
+This tutorial shows you how to run the recipe in one of two ways: using connector(s) to any link:https://docs.confluent.io/cloud/current/connectors/index.html[supported data source] or using ksqlDB's `INSERT INTO` functionality to mock the data.

--- a/_includes/tutorials/aggregating-average/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/aggregating-average/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/aggregating-count/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/aggregating-count/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/aggregating-sum/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/audit-logs/confluent/markup/dev/explanation.adoc
+++ b/_includes/tutorials/audit-logs/confluent/markup/dev/explanation.adoc
@@ -68,7 +68,7 @@ CREATE STREAM audit_log_topics
   WITH (
   KAFKA_TOPIC='topic-operations-audit-log', 
   PARTITIONS=6
-) 
+);
 ----
 
 This `CREATE STREAM` statement specifies to use (or create, if it doesn't exist yet) a Kafka topic to store the results of the stream.

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/ddos/confluent/code/tutorial-steps/dev/source.sql
+++ b/_includes/tutorials/ddos/confluent/code/tutorial-steps/dev/source.sql
@@ -10,4 +10,4 @@ CREATE SOURCE CONNECTOR IF NOT EXISTS network_traffic_source WITH (
   'rabbitmq.password' = '<my-rabbitmq-password>',
   'rabbitmq.queue'    = '<my-rabbitmq-queue>',
   'tasks.max'         = '1'
-)
+);

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -33,10 +33,10 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.0"
     implementation "org.slf4j:slf4j-simple:1.7.36"
-    implementation "org.apache.kafka:kafka-streams:2.8.1"
-    implementation "org.apache.kafka:kafka-clients:2.8.1"
+    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "org.apache.kafka:kafka-clients:3.1.0"
     
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:2.8.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/error-handling/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/error-handling/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/ProcessorException.java
+++ b/_includes/tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/ProcessorException.java
@@ -1,0 +1,8 @@
+package io.confluent.developer;
+
+public class ProcessorException extends RuntimeException {
+
+    public ProcessorException(String message) {
+        super(message);
+    }
+}

--- a/_includes/tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/StreamsUncaughtExceptionHandling.java
+++ b/_includes/tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/StreamsUncaughtExceptionHandling.java
@@ -17,11 +17,10 @@ import org.apache.kafka.streams.kstream.Produced;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 public class StreamsUncaughtExceptionHandling {
@@ -37,7 +36,7 @@ public class StreamsUncaughtExceptionHandling {
                 .mapValues(value -> {
                     counter++;
                     if (counter == 2 || counter == 8 || counter == 15) {
-                        throw new IllegalStateException("It works on my box!!!");
+                        throw new ProcessorException("It works on my box!!!");
                     }
                     return value.toUpperCase();
                 })
@@ -102,7 +101,7 @@ public class StreamsUncaughtExceptionHandling {
         Runtime.getRuntime().addShutdownHook(new Thread("streams-shutdown-hook") {
             @Override
             public void run() {
-                streams.close();
+                streams.close(Duration.ofSeconds(5));
             }
         });
 

--- a/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/console-consumer.sh
@@ -2,5 +2,5 @@ docker-compose exec broker kafka-console-consumer \
  --bootstrap-server broker:9092 \
  --topic output-topic \
  --from-beginning \
- --max-messages 12
+ --max-messages 6
 

--- a/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/expected-output.txt
+++ b/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/expected-output.txt
@@ -4,10 +4,4 @@ STREAMS
 LEAD
 TO
 CONFLUENT
-ALL
-STREAMS
-LEAD
-TO
-CONFLUENT
-GO
-Processed a total of 12 messages
+Processed a total of 6 messages

--- a/_includes/tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc
+++ b/_includes/tutorials/error-handling/kstreams/markup/dev/make-exception-handler.adoc
@@ -65,4 +65,10 @@ Now create the following file at `src/main/java/io/confluent/developer/MaxFailur
 
 You'll add the `StreamsUncaughtExceptionHandler` to your Kafka Streams application in the next step.
 
+There's one more step you'll need to take and that is creating a custom exception class `ProcessorException` that your exception handler will process. Create this simple Java class at `src/main/java/io/confluent/developer/ProcessorException.java`
+
++++++
+<pre class="snippet"><code class="java">{% include_raw tutorials/error-handling/kstreams/code/src/main/java/io/confluent/developer/ProcessorException.java %}</code></pre>
++++++
+
 NOTE: There is an older, deprecated version of https://kafka.apache.org/28/javadoc/org/apache/kafka/streams/KafkaStreams.html#setUncaughtExceptionHandler-java.lang.Thread.UncaughtExceptionHandler-[KafkaStreams.setUncaughtExceptionHandler] that takes an instance of a `java.lang.Thread.UncaughtExceptionHandler`.  It is advised for users to migrate to use the newer method.

--- a/_includes/tutorials/filtering/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/filtering/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/finding-distinct/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/finding-distinct/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/joining-stream-table/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/kafka-producer-application/kafka/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/merging/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/merging/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/message-ordering/kafka/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/message-ordering/kafka/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/messaging-modernization/confluent/markup/dev/process.adoc
+++ b/_includes/tutorials/messaging-modernization/confluent/markup/dev/process.adoc
@@ -1,7 +1,19 @@
 ++++
 <pre class="snippet expand-default"><code class="sql">
-{% include_raw shared/code/ccloud/comment-connector.sql %}
-{% include_raw tutorials/messaging-modernization/confluent/code/tutorial-steps/dev/source.sql %}
 {% include_raw tutorials/messaging-modernization/confluent/code/tutorial-steps/dev/process.sql %}
+{% include_raw shared/code/ccloud/comment-manual.sql %}
+{% include_raw tutorials/messaging-modernization/confluent/code/tutorial-steps/dev/manual.sql %}
 </code></pre>
+++++
+
+To validate that this recipe is working, run the following query:
+
+++++
+<pre class="snippet"><code class="sql">{% include_raw tutorials/messaging-modernization/ksql-test/code/tutorial-steps/test/validate.sql %}</code></pre>
+++++
+
+Your output should resemble:
+
+++++
+<pre class="snippet"><code class="text">{% include_raw tutorials/messaging-modernization/ksql-test/code/tutorial-steps/test/expected-outputs/rabbit_transactions.log %}</code></pre>
 ++++

--- a/_includes/tutorials/messaging-modernization/confluent/markup/dev/source.adoc
+++ b/_includes/tutorials/messaging-modernization/confluent/markup/dev/source.adoc
@@ -1,5 +1,7 @@
+If you have real end systems to connect to, adapt the sample connector configuration(s) below and run them from ksqlDB with `CREATE SOURCE CONNECTOR`.
+
 The concept in this tutorial can be applicable to any of the traditional message systems (RabbitMQ, Tibco, IBM MQ, ActiveMQ, etc.), and this specific tutorial uses the link:https://docs.confluent.io/cloud/current/connectors/cc-rabbitmq-source.html[RabbitMQ Source Connector for Confluent Cloud] which uses the AMQP protocol to communicate with RabbitMQ servers and persists the data in a Kafka topic.
 
 ++++
-<pre class="snippet"><code class="json">{% include_raw tutorials/messaging-modernization/confluent/code/tutorial-steps/dev/source.json %}</code></pre>
+<pre class="snippet"><code class="sql">{% include_raw tutorials/messaging-modernization/confluent/code/tutorial-steps/dev/source.sql %}</code></pre>
 ++++

--- a/_includes/tutorials/multiple-event-types/kafka/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/multiple-event-types/kafka/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/.gitignore
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/.gitignore
@@ -1,0 +1,1 @@
+tutorial-steps/dev/outputs

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -33,9 +33,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.0"
     implementation "org.slf4j:slf4j-simple:1.7.36"
-    implementation "org.apache.kafka:kafka-streams:2.8.1"
-    implementation "io.confluent:kafka-streams-avro-serde:6.2.1"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:2.8.1"
+    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:6.2.1
+    image: confluentinc/cp-zookeeper:7.1.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:6.2.1
+    image: confluentinc/cp-kafka:7.1.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:6.2.1
+    image: confluentinc/cp-schema-registry:7.1.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/src/main/java/io/confluent/developer/NamingChangelogAndRepartitionTopics.java
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/src/main/java/io/confluent/developer/NamingChangelogAndRepartitionTopics.java
@@ -2,15 +2,6 @@ package io.confluent.developer;
 
 
 import io.confluent.common.utils.TestUtils;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.serialization.Serde;
@@ -27,6 +18,16 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.StreamJoined;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 
 public class NamingChangelogAndRepartitionTopics {
 
@@ -69,7 +70,7 @@ public class NamingChangelogAndRepartitionTopics {
                                     .toStream();
 
         joinedStream = inputStream.join(countStream, (v1, v2) -> v1 + v2.toString(),
-                                                              JoinWindows.of(Duration.ofMillis(100)),
+                                                              JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(100)),
                                                               StreamJoined.with(longSerde, stringSerde, longSerde));
     } else {
         countStream = inputStream.groupByKey(Grouped.with("count", longSerde, stringSerde))
@@ -77,7 +78,7 @@ public class NamingChangelogAndRepartitionTopics {
                                    .toStream();
 
         joinedStream = inputStream.join(countStream, (v1, v2) -> v1 + v2.toString(),
-                                                              JoinWindows.of(Duration.ofMillis(100)),
+                                                              JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofMillis(100)),
                                                               StreamJoined.with(longSerde, stringSerde, longSerde)
                                                                           .withName("join").withStoreName("the-join-store"));
     }

--- a/_includes/tutorials/online-dating/confluent/markup/dev/process.adoc
+++ b/_includes/tutorials/online-dating/confluent/markup/dev/process.adoc
@@ -1,7 +1,19 @@
 ++++
 <pre class="snippet expand-default"><code class="sql">
-{% include_raw shared/code/ccloud/comment-connector.sql %}
-{% include_raw tutorials/online-dating/confluent/code/tutorial-steps/dev/source.sql %}
 {% include_raw tutorials/online-dating/confluent/code/tutorial-steps/dev/process.sql %}
+{% include_raw shared/code/ccloud/comment-manual.sql %}
+{% include_raw tutorials/online-dating/confluent/code/tutorial-steps/dev/manual.sql %}
 </code></pre>
+++++
+
+To validate that this recipe is working, run the following query:
+
+++++
+<pre class="snippet"><code class="sql">{% include_raw tutorials/online-dating/ksql-test/code/tutorial-steps/test/validate.sql %}</code></pre>
+++++
+
+Your output should resemble:
+
+++++
+<pre class="snippet"><code class="text">{% include_raw tutorials/online-dating/ksql-test/code/tutorial-steps/test/expected-outputs/conversations.log %}</code></pre>
 ++++

--- a/_includes/tutorials/online-dating/confluent/markup/dev/source.adoc
+++ b/_includes/tutorials/online-dating/confluent/markup/dev/source.adoc
@@ -1,3 +1,5 @@
+If you have real end systems to connect to, adapt the sample connector configuration(s) below and run them from ksqlDB with `CREATE SOURCE CONNECTOR`.
+
 ++++
-<pre class="snippet"><code class="json">{% include_raw tutorials/online-dating/confluent/code/tutorial-steps/dev/source.json %}</code></pre>
+<pre class="snippet"><code class="sql">{% include_raw tutorials/online-dating/confluent/code/tutorial-steps/dev/source.sql %}</code></pre>
 ++++

--- a/_includes/tutorials/produce-consume-lang/scala/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/produce-consume-lang/scala/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/serialization/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/serialization/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Jun 17 09:15:50 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/session-windows/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/session-windows/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/sliding-windows/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/sliding-windows/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/splitting/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/splitting/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/streams-to-table/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/streams-to-table/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/time-concepts/ksql/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/time-concepts/ksql/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/transforming/kafka/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/transforming/kafka/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue Mar 31 18:21:44 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/transforming/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/transforming/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue May 05 07:49:42 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/tumbling-windows/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/udf/ksql/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/udf/ksql/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/_includes/tutorials/window-final-result/kstreams/code/gradle/wrapper/gradle-wrapper.properties
+++ b/_includes/tutorials/window-final-result/kstreams/code/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description

Includes the following:

- #1256 
- Upgrade all tutorials (Java based) to use Gradle version 7.4.2
- Reorder steps to promote `INSERT INTO` over connector (https://github.com/confluentinc/kafka-tutorials/pull/1259 and https://github.com/confluentinc/kafka-tutorials/pull/1260)
- Other small fixes

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
