### PR TITLE
Remove threads and use MockConsumer.schedulePollTask

### DIFF
--- a/_includes/tutorials/kafka-consumer-application/kafka/code/src/test/java/io/confluent/developer/KafkaConsumerApplicationTest.java
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/src/test/java/io/confluent/developer/KafkaConsumerApplicationTest.java
@@ -33,14 +33,10 @@ public class KafkaConsumerApplicationTest {
     final MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
 
     final KafkaConsumerApplication consumerApplication = new KafkaConsumerApplication(mockConsumer, recordsHandler);
-
-    // the KafkaConsumerApplication runs synchronously so the test needs to run
-    // the application in its own thread
-    new Thread(() -> consumerApplication.runConsume(testConsumerProps)).start();
-    Thread.sleep(500);
-    addTopicPartitionsAssignmentAndAddConsumerRecords(topic, mockConsumer, topicPartition);
-    Thread.sleep(500);
-    consumerApplication.shutdown();
+    
+    mockConsumer.schedulePollTask(() -> addTopicPartitionsAssignmentAndAddConsumerRecords(topic, mockConsumer, topicPartition));
+    mockConsumer.schedulePollTask(consumerApplication::shutdown);
+    consumerApplication.runConsume(testConsumerProps);
 
     final List<String> expectedWords = Arrays.asList("foo", "bar", "baz");
     List<String> actualRecords = Files.readAllLines(tempFilePath);


### PR DESCRIPTION
### Description

The test uses threads which leads to flaky failures due to race conditions.  To fix this, the test should use the `MockConsumer.schedulePollTask`instead.  

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->
This PR includes a testing change only, so no need to view deployed tutorial.

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
