### PR TITLE
Rename kafkacat to kcat

### DIFF
--- a/_data/harnesses/count-messages/kafka.yml
+++ b/_data/harnesses/count-messages/kafka.yml
@@ -32,7 +32,7 @@ dev:
           render:
             file: tutorials/count-messages/kafka/markup/dev/02c-wait-for-containers.adoc
 
-    - title: Run kafkacat to count the messages
+    - title: Run kcat to count the messages
       content:
         - action: execute
           file: tutorial-steps/dev/03a-count-messages.sh
@@ -49,7 +49,7 @@ dev:
             file: tutorials/count-messages/kafka/markup/dev/05-clean-up.adoc
 
 
-    - title: Use kafkacat with Confluent Cloud
+    - title: Use kcat with Confluent Cloud
       content:
         - action: execute
         # There's nothing to run here because we're not testing against CCloud yet

--- a/_includes/tutorials/connect-add-key-to-source/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/code/docker-compose.yml
@@ -68,9 +68,9 @@ services:
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: "1"
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: "1"
 
-  kafkacat:
-    image: edenhill/kafkacat:1.5.0
-    container_name: kafkacat
+  kcat:
+    image: edenhill/kcat:1.7.1
+    container_name: kcat
     links:
       - broker
     entrypoint: 

--- a/_includes/tutorials/connect-add-key-to-source/kafka/code/tutorial-steps/dev/consume-topic.sh
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/code/tutorial-steps/dev/consume-topic.sh
@@ -1,3 +1,3 @@
-docker exec -i kafkacat kafkacat -b broker:9092 -t postgres_cities \
+docker exec -i kcat kcat -b broker:9092 -t postgres_cities \
             -C -s avro -r http://schema-registry:8081 -e \
             -f 'Key     (%K bytes):\t%k\nPayload (%S bytes):\t%s\n--\n'

--- a/_includes/tutorials/connect-add-key-to-source/kafka/markup/dev/consume-topic.adoc
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/markup/dev/consume-topic.adoc
@@ -1,4 +1,4 @@
-With the connector running let's now inspect the data on the Kafka topic. Here we'll use `kafkacat` because of its rich capabilities for inspecting and displaying details of Kafka messages:
+With the connector running let's now inspect the data on the Kafka topic. Here we'll use `kcat` because of its rich capabilities for inspecting and displaying details of Kafka messages:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/connect-add-key-to-source/kafka/code/tutorial-steps/dev/consume-topic.sh %}</code></pre>

--- a/_includes/tutorials/connect-add-key-to-source/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/connect-add-key-to-source/ksql/code/docker-compose.yml
@@ -103,9 +103,9 @@ services:
     volumes:
       - ./src:/opt/app/src
 
-  kafkacat:
-    image: edenhill/kafkacat:1.5.0
-    container_name: kafkacat
+  kcat:
+    image: edenhill/kcat:1.7.1
+    container_name: kcat
     links:
       - broker
     entrypoint: 

--- a/_includes/tutorials/count-messages/confluent/code/tutorial-steps/dev/03a-count-messages.sh
+++ b/_includes/tutorials/count-messages/confluent/code/tutorial-steps/dev/03a-count-messages.sh
@@ -1,6 +1,6 @@
 docker run -it --network=host \
     -v ${PWD}/configuration/ccloud.properties:/tmp/configuration/ccloud.properties \
-    edenhill/kcat:1.7.0 kafkacat \
+    edenhill/kcat:1.7.0 kcat \
          -F /tmp/configuration/ccloud.properties \
          -C -t test-topic \
          -e -q \

--- a/_includes/tutorials/count-messages/confluent/markup/dev/03a-count-messages.adoc
+++ b/_includes/tutorials/count-messages/confluent/markup/dev/03a-count-messages.adoc
@@ -1,6 +1,6 @@
 You can count the number of messages in a Kafka topic simply by consuming the entire topic and counting how many messages are read. 
 
-To do this from the commandline you can use the https://github.com/edenhill/kafkacat[`kafkacat`] tool which is built around the https://en.wikipedia.org/wiki/Pipeline_(Unix)[Unix philosophy of pipelines]. This means that you can pipe the output (messages) from kafkacat into another tool like `wc` to count the number of messages.
+To do this from the commandline you can use the https://github.com/edenhill/kcat[`kcat`] tool which is built around the https://en.wikipedia.org/wiki/Pipeline_(Unix)[Unix philosophy of pipelines]. This means that you can pipe the output (messages) from kcat into another tool like `wc` to count the number of messages.
 
 As input, pass in the `configuration/ccloud.properties` file that you created in an earlier step.
 
@@ -10,15 +10,15 @@ As input, pass in the `configuration/ccloud.properties` file that you created in
 
 Let's take a close look at the commandline soup we've used here to count the messages. 
 
-* `docker exec kafkacat` runs the following command with its arguments in the Docker container called `kafkacat`
+* `docker exec kcat` runs the following command with its arguments in the Docker container called `kcat`
 * `\` is a line continuation character
-** `kafkacat` runs kafkacat itself, passing in arguments as follows: 
+** `kcat` runs kcat itself, passing in arguments as follows: 
 *** `-F` Kafka cluster connection information
 *** `-C` act as a consumer
 *** `-t` read data from the `test-topic` topic
 *** `-e` exit once at the end of the topic
 *** `-q` run quietly
-** `|` pipes the messages from kafkacat to the next command 
+** `|` pipes the messages from kcat to the next command 
 ** `grep -v "Reading configuration from file"` skip the log message
 ** `wc -l` reads the piped messages and writes the number of lines in total (one message per line) to screen
 

--- a/_includes/tutorials/count-messages/confluent/markup/dev/answer-short.adoc
+++ b/_includes/tutorials/count-messages/confluent/markup/dev/answer-short.adoc
@@ -1,4 +1,4 @@
-If your Kafka topic is in https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud], consume the entire topic using `kafkacat` and count how many messages are read.
+If your Kafka topic is in https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud], consume the entire topic using `kcat` and count how many messages are read.
   
 +++++
 <pre class="snippet"><code class="java">{% include_raw tutorials/count-messages/confluent/code/tutorial-steps/dev/03a-count-messages.sh %}</code></pre>

--- a/_includes/tutorials/count-messages/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/count-messages/kafka/code/docker-compose.yml
@@ -126,9 +126,9 @@ services:
       - ./src:/opt/app/src
       - ./test:/opt/app/test
 
-  kafkacat:
-    image: edenhill/kafkacat:1.6.0
-    container_name: kafkacat
+  kcat:
+    image: edenhill/kcat:1.7.1
+    container_name: kcat
     links:
       - broker
     entrypoint: 

--- a/_includes/tutorials/count-messages/kafka/code/tutorial-steps/dev/03a-count-messages.sh
+++ b/_includes/tutorials/count-messages/kafka/code/tutorial-steps/dev/03a-count-messages.sh
@@ -1,3 +1,3 @@
-docker exec kafkacat \
-    kafkacat -b broker:29092 -C -t pageviews -e -q | \
+docker exec kcat \
+    kcat -b broker:29092 -C -t pageviews -e -q | \
     wc -l

--- a/_includes/tutorials/count-messages/kafka/code/tutorial-steps/dev/04b-count-messages-ccloud.sh
+++ b/_includes/tutorials/count-messages/kafka/code/tutorial-steps/dev/04b-count-messages-ccloud.sh
@@ -1,4 +1,4 @@
-docker run --rm edenhill/kafkacat:1.6.0 \
+docker run --rm edenhill/kcat:1.7.1 \
     -X security.protocol=SASL_SSL -X sasl.mechanisms=PLAIN \
     -X ssl.ca.location=./etc/ssl/cert.pem -X api.version.request=true \
     -X sasl.username="${CCLOUD_API_KEY}" \

--- a/_includes/tutorials/count-messages/kafka/markup/dev/03a-count-messages.adoc
+++ b/_includes/tutorials/count-messages/kafka/markup/dev/03a-count-messages.adoc
@@ -1,6 +1,6 @@
 You can count the number of messages in a Kafka topic simply by consuming the entire topic and counting how many messages are read. 
 
-To do this from the commandline you can use the https://github.com/edenhill/kafkacat[`kafkacat`] tool which can act as a consumer (and producer) and is built around the https://en.wikipedia.org/wiki/Pipeline_(Unix)[Unix philosophy of pipelines]. This means that you can pipe the output (messages) from kafkacat into another tool to count the number of messages.
+To do this from the commandline you can use the https://github.com/edenhill/kcat[`kcat`] tool which can act as a consumer (and producer) and is built around the https://en.wikipedia.org/wiki/Pipeline_(Unix)[Unix philosophy of pipelines]. This means that you can pipe the output (messages) from kcat into another tool to count the number of messages.
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/count-messages/kafka/code/tutorial-steps/dev/03a-count-messages.sh %}</code></pre>
@@ -8,15 +8,15 @@ To do this from the commandline you can use the https://github.com/edenhill/kafk
 
 Let's take a close look at the commandline soup we've used here to count the messages. 
 
-* `docker exec kafkacat` runs the following command with its arguments in the Docker container called `kafkacat`
+* `docker exec kcat` runs the following command with its arguments in the Docker container called `kcat`
 * `\` is a line continuation character
-** `kafkacat` runs kafkacat itself, passing in arguments as follows: 
+** `kcat` runs kcat itself, passing in arguments as follows: 
 *** `-b` the location of the cluster broker(s)
 *** `-C` act as a consumer
 *** `-t` read data from the `pageviews` topic
 *** `-e` exit once at the end of the topic
 *** `-q` run quietly
-** `|` pipes the messages from kafkacat to the next command 
+** `|` pipes the messages from kcat to the next command 
 ** `wc` reads the piped messages and writes the count to screen
 *** `-l` specifies to count the number of lines in total (one message per line). Contrast this to `-c` which would return the number of bytes. 
 

--- a/_includes/tutorials/count-messages/kafka/markup/dev/04a-set-env.adoc
+++ b/_includes/tutorials/count-messages/kafka/markup/dev/04a-set-env.adoc
@@ -1,4 +1,4 @@
-In the example above we provision an entire stack include kafkacat connecting to a broker in a Docker container. You can use kafkacat from a Docker container to connect to Kafka clusters elsewhere, such as Confluent Cloud. 
+In the example above we provision an entire stack include kcat connecting to a broker in a Docker container. You can use kcat from a Docker container to connect to Kafka clusters elsewhere, such as Confluent Cloud. 
 
 If you don't have an account yet, sign up for link:https://www.confluent.io/confluent-cloud/tryfree/[Confluent Cloud]. 
 Use the promo code `CC100KTS` to receive an additional $100 free usage on Confluent Cloud (https://www.confluent.io/confluent-cloud-promo-disclaimer[details]). 

--- a/_includes/tutorials/count-messages/kafka/markup/dev/04b-count-messages-ccloud.adoc
+++ b/_includes/tutorials/count-messages/kafka/markup/dev/04b-count-messages-ccloud.adoc
@@ -1,4 +1,4 @@
-Now we can run kafkacat (passing in the necessary Confluent Cloud details from environment variables) to count the number of messages in a Kafka topic simply by consuming the entire topic and counting how many messages are read. 
+Now we can run kcat (passing in the necessary Confluent Cloud details from environment variables) to count the number of messages in a Kafka topic simply by consuming the entire topic and counting how many messages are read. 
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/count-messages/kafka/code/tutorial-steps/dev/04b-count-messages-ccloud.sh %}</code></pre>

--- a/_includes/tutorials/count-messages/kafka/markup/dev/answer-short.adoc
+++ b/_includes/tutorials/count-messages/kafka/markup/dev/answer-short.adoc
@@ -1,4 +1,4 @@
-Consume the entire Kafka topic using `kafkacat`, and count how many messages are read.
+Consume the entire Kafka topic using `kcat`, and count how many messages are read.
   
 +++++
 <pre class="snippet"><code class="java">{% include_raw tutorials/count-messages/kafka/code/tutorial-steps/dev/03a-count-messages.sh %}</code></pre>

--- a/_includes/tutorials/count-messages/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/count-messages/ksql/code/docker-compose.yml
@@ -139,9 +139,9 @@ services:
       - ./src:/opt/app/src
       - ./test:/opt/app/test
 
-  kafkacat:
-    image: edenhill/kafkacat:1.6.0
-    container_name: kafkacat
+  kcat:
+    image: edenhill/kcat:1.7.1
+    container_name: kcat
     links:
       - broker
     entrypoint: 

--- a/_includes/tutorials/generate-test-data-streams/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/generate-test-data-streams/kafka/code/docker-compose.yml
@@ -82,9 +82,9 @@ services:
         #
         sleep infinity
         
-  kafkacat:
-    image: edenhill/kafkacat:1.5.0
-    container_name: kafkacat
+  kcat:
+    image: edenhill/kcat:1.7.1
+    container_name: kcat
     links:
       - broker
     entrypoint: 

--- a/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/consume-topic-01.sh
+++ b/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/consume-topic-01.sh
@@ -1,4 +1,4 @@
-docker exec -i kafkacat kafkacat -b broker:9092 -t clicks \
+docker exec -i kcat kcat -b broker:9092 -t clicks \
             -s value=avro -r http://schema-registry:8081        \
             -u -f 'Key     (%K bytes):\t%k\nPayload (%S bytes):\t%s\n--\n' \
             -C -c5 -o end

--- a/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/consume-topic-02a.sh
+++ b/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/consume-topic-02a.sh
@@ -1,4 +1,4 @@
-docker exec -i kafkacat kafkacat -b broker:9092 -t devices \
+docker exec -i kcat kcat -b broker:9092 -t devices \
             -s key=s -s value=avro -r http://schema-registry:8081        \
             -f 'Key     (%K bytes):\t%k\nPayload (%S bytes):\t%s\n--\n' \
             -C -c3 -o beginning 2>/dev/null

--- a/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/consume-topic-02b.sh
+++ b/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/consume-topic-02b.sh
@@ -1,4 +1,4 @@
-docker exec -i kafkacat kafkacat -b broker:9092 -t traffic \
+docker exec -i kcat kcat -b broker:9092 -t traffic \
             -s key=s -s value=avro -r http://schema-registry:8081        \
             -f 'Key     (%K bytes):\t%k\nPayload (%S bytes):\t%s\n--\n' \
             -C -c5 -o end -u 2>/dev/null            

--- a/_includes/tutorials/generate-test-data-streams/kafka/markup/dev/consume-topic-01.adoc
+++ b/_includes/tutorials/generate-test-data-streams/kafka/markup/dev/consume-topic-01.adoc
@@ -1,4 +1,4 @@
-With the connector running let's now inspect the data that's being generated to the Kafka topic. Here we'll use kafkacat, but you could use any Kafka consumer if you wanted.
+With the connector running let's now inspect the data that's being generated to the Kafka topic. Here we'll use kcat, but you could use any Kafka consumer if you wanted.
 
 +++++
 <pre class="snippet"><code class="sql">{% include_raw tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/consume-topic-01.sh %}</code></pre>

--- a/_includes/tutorials/generate-test-data-streams/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/generate-test-data-streams/ksql/code/docker-compose.yml
@@ -103,9 +103,9 @@ services:
     volumes:
       - ./src:/opt/app/src
 
-  # kafkacat:
-  #   image: edenhill/kafkacat:1.5.0
-  #   container_name: kafkacat
+  # kcat:
+  #   image: edenhill/kcat:1.7.1
+  #   container_name: kcat
   #   links:
   #     - broker
   #   entrypoint: 

--- a/tools/wordlist.txt
+++ b/tools/wordlist.txt
@@ -857,6 +857,7 @@ kafkaconnect
 kafkaconsumer
 kafkarest
 kafkastore
+kcat
 keepConsuming
 keepalive
 keyValueStoreBuilder


### PR DESCRIPTION
### Description

Rename kafkacat to kcat, per product name change
https://github.com/edenhill/kcat


### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/kcat/how-to-count-messages-on-a-kafka-topic/kafka.html


### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
