### PR TITLE
DP-8085 - Migrate to Semaphore self-hosted agent

### DIFF
--- a/.semaphore/live-site-deploy.yml
+++ b/.semaphore/live-site-deploy.yml
@@ -2,8 +2,7 @@ version: v1.0
 name: Kafka Tutorials live site deployment
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: s1-prod-ubuntu20-04-amd64-1
 
 blocks:
   - task:

--- a/.semaphore/pr-staging-deploy.yml
+++ b/.semaphore/pr-staging-deploy.yml
@@ -2,8 +2,7 @@ version: v1.0
 name: Kafka Tutorials staging site deployment
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: s1-prod-ubuntu20-04-amd64-1
 
 blocks:
   - task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,6 +9,7 @@ global_job_config:
   prologue:
     commands:
       - echo $SEMAPHORE_WORKFLOW_ID
+      - sudo add-apt-repository ppa:cwchien/gradle -y
       - checkout
       - make install-vault
       - . vault-bin/vault-setup

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,13 +2,13 @@ version: v1.0
 name: Kafka Tutorials pipeline
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: s1-prod-ubuntu20-04-amd64-1
 global_job_config:
   secrets:
     - name: vault_sem2_approle
   prologue:
     commands:
+      - echo $SEMAPHORE_WORKFLOW_ID
       - checkout
       - make install-vault
       - . vault-bin/vault-setup
@@ -48,6 +48,7 @@ blocks:
     task:
       prologue:
         commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
           - checkout
           - cache restore
           - npm install
@@ -64,6 +65,7 @@ blocks:
     task:
       prologue:
         commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
           - checkout
           - cache restore
       jobs:
@@ -81,6 +83,7 @@ blocks:
     task:
       prologue:
         commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
           - sudo apt-get install gradle-7.4.2 -y
           - sudo update-alternatives --set gradle /usr/lib/gradle/7.4.2/bin/gradle          
       jobs:
@@ -251,6 +254,7 @@ blocks:
     task:
       prologue:
         commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
           - sudo apt-get install gradle-6.8.3 -y
           - sudo update-alternatives --set gradle /usr/lib/gradle/6.8.3/bin/gradle
       jobs:
@@ -368,6 +372,7 @@ blocks:
     task:
       prologue:
         commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
           - sudo apt-get install gradle-6.8.3 -y
           - sudo update-alternatives --set gradle /usr/lib/gradle/6.8.3/bin/gradle
       jobs:

--- a/.semaphore/staging-site-deploy.yml
+++ b/.semaphore/staging-site-deploy.yml
@@ -2,8 +2,7 @@ version: v1.0
 name: Kafka Tutorials staging site deployment
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu1804
+    type: s1-prod-ubuntu20-04-amd64-1
 
 blocks:
   - task:


### PR DESCRIPTION
# Background
In the current Semaphore cloud offering, all of the Semaphore build nodes are controlled by Semaphore. Thus, we are unable to control what resources they can access. 
It also represents security concerns because Semaphore has access to what is on those nodes, including our credentials from Vault.
The DevProd team will be migrating the existing SemaphoreCI pipelines using linux machines to start using self-hosted Semaphore build agents.
Deadline to migrate the SemaphoreCI jobs to self hosted agents is July 22nd, 2022
The DevProd team will start creating PRs to migrate your existing Semaphore jobs to the self-hosted agents by July 10, 2022.

**This migrates to Semaphore self-hosted agent**

# Changelog
Details on the self-hosted agent host configuration are described here : https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2820542346/Semaphore+Self+Hosted+Agents

# Migration Changes
This automated pull request changes
* Pipeline YAML files under .semaphore folder

# Actions
* If you are happy with the changes, feel free to merge.
* If you have concerns about the changes, comment on this pull request, tagging the Developer Productivity team `(@confluentinc/tools)`.
* If you happen to have time to look at any of the failures and can help us out, that would be greatly appreciated.
* If the CI does not pass, we may fix some simpler issues on this pull request, but if there is a deeper problem associated with the migration, we may create a task for your team to fix.
