### PR TITLE
updating swiftype tags -- category -> contentType

### DIFF
--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta class="swiftype" name="site-id" data-type="integer" content="3" />
   <meta class="swiftype" name="docs-boost" data-type="integer" content="6" />
-  <meta class="swiftype" name="contentTypes" data-type="string" content="recipe" />
+  <meta class="swiftype" name="contentType" data-type="string" content="recipe" />
   <meta name="description" content="In this tutorial, learn how to {{ site.data.tutorials[page.static_data].meta-description }} using {{ site.data.stacks[page.stack].pretty }}, with step-by-step instructions and examples.">
   {% if site.data.tutorials[page.static_data].canonical %}
     {% unless page.stack == site.data.tutorials[page.static_data].canonical or page.stack == 'ksql' %}

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta class="swiftype" name="site-id" data-type="integer" content="3" />
   <meta class="swiftype" name="docs-boost" data-type="integer" content="6" />
-  <meta class="swiftype" name="contentType" data-type="string" content="recipe" />
+  <meta class="swiftype" name="contentType" data-type="string" content="tutorial">
   <meta name="description" content="In this tutorial, learn how to {{ site.data.tutorials[page.static_data].meta-description }} using {{ site.data.stacks[page.stack].pretty }}, with step-by-step instructions and examples.">
   {% if site.data.tutorials[page.static_data].canonical %}
     {% unless page.stack == site.data.tutorials[page.static_data].canonical or page.stack == 'ksql' %}

--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta class="swiftype" name="site-id" data-type="integer" content="3" />
   <meta class="swiftype" name="docs-boost" data-type="integer" content="6" />
-  <meta class="swiftype" name="category" data-type="string" content="recipe" />
+  <meta class="swiftype" name="contentTypes" data-type="string" content="recipe" />
   <meta name="description" content="In this tutorial, learn how to {{ site.data.tutorials[page.static_data].meta-description }} using {{ site.data.stacks[page.stack].pretty }}, with step-by-step instructions and examples.">
   {% if site.data.tutorials[page.static_data].canonical %}
     {% unless page.stack == site.data.tutorials[page.static_data].canonical or page.stack == 'ksql' %}

--- a/_layouts/tutorial.html
+++ b/_layouts/tutorial.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta class="swiftype" name="site-id" data-type="integer" content="3" />
   <meta class="swiftype" name="docs-boost" data-type="integer" content="6" />
-  <meta class="swiftype" name="category" data-type="string" content="tutorial" />
+  <meta class="swiftype" name="contentType" data-type="string" content="tutorial" />
   <meta name="description" content="In this tutorial, learn how to {{ site.data.tutorials[page.static_data].meta-description }} using {{ site.data.stacks[page.stack].pretty }}, with step-by-step instructions and examples.">
   {% if site.data.tutorials[page.static_data].canonical %}
     {% unless page.stack == site.data.tutorials[page.static_data].canonical or page.stack == 'ksql' %}


### PR DESCRIPTION
### Description

We had an issue on .io where we needed to change from `category` to `contentType` and it makes sense to keep everything aligned.

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
