### PR TITLE
change harness_runner egg permissions to non-root in semaphore build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -21,6 +21,7 @@ global_job_config:
       - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
       - docker login --username $DOCKER_USER --password $DOCKER_APIKEY confluent-docker.jfrog.io
       - sudo pip3 install -e harness_runner/
+      - sudo chown -R semaphore:semaphore harness_runner/ # mitigation for https://github.com/confluentinc/kafka-tutorials/issues/1324
       - >
         find _includes/tutorials/**/ksql -name docker-compose.yml | xargs -I {} sed -i -E "s/(\s+)(KSQL_CONFIG_DIR.*)/\1\2\\n\1KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: \"false\"/g" {}
 


### PR DESCRIPTION
This mitigates https://github.com/confluentinc/kafka-tutorials/issues/1324 and is
a short-term fix until https://github.com/confluentinc/kafka-tutorials/issues/1326
is taken on.

### Description

https://github.com/confluentinc/kafka-tutorials/issues/1324

### Staging Docs

N/A

### New tutorial checklist

N/A