### PR TITLE
add a wait before validating ksqlDB recipe tests relying on table output

### DIFF
--- a/_data/harnesses/logistics/ksql-test.yml
+++ b/_data/harnesses/logistics/ksql-test.yml
@@ -44,4 +44,20 @@ test:
             skip: true
           stdin:
             - file: ../../confluent/code/tutorial-steps/dev/manual.sql
+
+        - name: wait for table to be populated
+          action: sleep
+          ms: 5000
+          render:
+            skip: true
+
+        - action: docker_ksql_cli_session
+          container: ksqldb-cli
+          docker_bootup_file: start-cli.sh
+          stdout:
+            directory: tutorial-steps/test/outputs
+          column_width: 75
+          render:
+            skip: true
+          stdin:
             - file: tutorial-steps/test/validate.sql

--- a/_data/harnesses/mainframe-offload/ksql-test.yml
+++ b/_data/harnesses/mainframe-offload/ksql-test.yml
@@ -44,4 +44,20 @@ test:
             skip: true
           stdin:
             - file: ../../confluent/code/tutorial-steps/dev/manual.sql
+
+        - name: wait for table to be populated
+          action: sleep
+          ms: 5000
+          render:
+            skip: true
+
+        - action: docker_ksql_cli_session
+          container: ksqldb-cli
+          docker_bootup_file: start-cli.sh
+          stdout:
+            directory: tutorial-steps/test/outputs
+          column_width: 75
+          render:
+            skip: true
+          stdin:
             - file: tutorial-steps/test/validate.sql

--- a/_data/harnesses/model-retraining/ksql-test.yml
+++ b/_data/harnesses/model-retraining/ksql-test.yml
@@ -44,4 +44,20 @@ test:
             skip: true
           stdin:
             - file: ../../confluent/code/tutorial-steps/dev/manual.sql
+
+        - name: wait for table to be populated
+          action: sleep
+          ms: 5000
+          render:
+            skip: true
+
+        - action: docker_ksql_cli_session
+          container: ksqldb-cli
+          docker_bootup_file: start-cli.sh
+          stdout:
+            directory: tutorial-steps/test/outputs
+          column_width: 75
+          render:
+            skip: true
+          stdin:
             - file: tutorial-steps/test/validate.sql

--- a/_data/harnesses/payment-status-check/ksql-test.yml
+++ b/_data/harnesses/payment-status-check/ksql-test.yml
@@ -44,4 +44,20 @@ test:
             skip: true
           stdin:
             - file: ../../confluent/code/tutorial-steps/dev/manual.sql
+
+        - name: wait for table to be populated
+          action: sleep
+          ms: 5000
+          render:
+            skip: true
+
+        - action: docker_ksql_cli_session
+          container: ksqldb-cli
+          docker_bootup_file: start-cli.sh
+          stdout:
+            directory: tutorial-steps/test/outputs
+          column_width: 75
+          render:
+            skip: true
+          stdin:
             - file: tutorial-steps/test/validate.sql


### PR DESCRIPTION
The handful of tests that query table output tend to be flaky due to the
async nature of ksqlDB. There's no guarantee that table result are
available after corresponding INSERTS. Other recipes that validate
via a stream query like "SELECT ... EMIT CHANGES LIMIT n;" aren't
susceptible to the same test flakiness since they will block on
n rows being emitted..

### Description

https://github.com/confluentinc/kafka-tutorials/issues/1328

### Staging Docs

N/A

### New tutorial checklist

N/A