### PR TITLE
HOT FIX: Use double backslash for escape to fix the build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -42,7 +42,7 @@ promotions:
   - name: Stage PRs for review 
     pipeline_file: pr-staging-deploy.yml
     auto_promote:
-      when: "branch != 'master' and branch != 'release' and branch !~ '^dependabot\.'"
+      when: "branch != 'master' and branch != 'release' and branch !~ '^dependabot\\.'"
 
 blocks:
   - name: Build the website


### PR DESCRIPTION
### Description

Self-hosted semaphore needs a `\\` for escaping

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
