### PR TITLE
Syntax hl

### DIFF
--- a/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,6 +1,6 @@
 Run the following command to start a Confluent CLI consumer to view consume the events that have been filtered by your application:
 
-```
+```bash
 confluent kafka topic consume movie-tickets-sold -b --print-key
 ```
 

--- a/_includes/tutorials/aggregating-sum/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/aggregating-sum/confluent/markup/dev/run-consumer.adoc
@@ -1,6 +1,6 @@
 Leaving your original terminal running, open another to consume the events that have been filtered by your application:
 
-```
+```bash
 confluent kafka topic consume movie-revenue -b --print-key
 ```
 

--- a/_includes/tutorials/count-messages/confluent/markup/dev/create-topic.adoc
+++ b/_includes/tutorials/count-messages/confluent/markup/dev/create-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```
+```bash
 confluent kafka topic create test-topic
 ```     

--- a/_includes/tutorials/error-handling/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/error-handling/confluent/markup/dev/run-consumer.adoc
@@ -8,7 +8,7 @@ Now that you've ran the Kafka Streams application, it should have shut itself do
 
 Let's now run the Confluent CLI to confirm the output:
 
-```
+```bash
 confluent kafka topic consume output-topic --from-beginning
 ```
 

--- a/_includes/tutorials/filtering/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/filtering/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,6 +1,6 @@
 Run the following command to start a Confluent CLI consumer to view the distinct click events:
 
-```
+```bash
 confluent kafka topic consume filtered-publications -b --value-format avro
 ```
 

--- a/_includes/tutorials/finding-distinct/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/finding-distinct/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,6 +1,6 @@
 Run the following command to start a Confluent CLI consumer to view the distinct click events:
 
-```
+```bash
 confluent kafka topic consume distinct-clicks -b --value-format avro
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-consume-rated-movies.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-consume-rated-movies.adoc
@@ -1,6 +1,6 @@
 Before you start producing ratings, it's a good idea to set up the consumer on the output topic. This way, as soon as you produce ratings (and they're joined to movies), you'll see the results right away. Run this to get ready to consume the rated movies:
 
-```
+```bash
 confluent kafka topic consume rated-movies --from-beginning --value-format avro
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-movies.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-movies.adoc
@@ -1,6 +1,6 @@
 In a new terminal, run:
 
-```
+```bash
 confluent kafka topic produce movies --value-format avro --schema src/main/avro/movie.avsc
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-ratings.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-ratings.adoc
@@ -1,6 +1,6 @@
 Run the following in a new terminal window. This process is the most fun if you can see this and the previous terminal (which is consuming the rated movies) at the same time. If your terminal program lets you do horizontal split panes, try it that way:
 
-```
+```bash
 confluent kafka topic produce ratings --value-format avro --schema src/main/avro/rating.avsc
 ```
 

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,6 +1,6 @@
 Using a terminal window, run the following command to start a Confluent CLI producer:
 
-```
+```bash
 confluent kafka topic produce input-topic
 ```
 

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```
+```bash
 confluent kafka topic create input-topic
 ```

--- a/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/create-topic.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/create-topic.adoc
@@ -4,7 +4,7 @@ In this step we're going to create a topic for use during this tutorial.
 
 Open a new terminal window and then run this command to create the topic that the producer can write to
 
-```
+```bash
 confluent kafka topic create output-topic
 ```
 

--- a/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/run-consumer.adoc
@@ -1,6 +1,6 @@
 Now run a console consumer that will read topics from the output topic to confirm your application published the expected records.
 
-```
+```bash
 confluent kafka topic consume output-topic --from-beginning --print-key --delimiter " : "
 ```
 

--- a/_includes/tutorials/kafka-producer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/kafka-producer-application/confluent/markup/dev/make-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```
+```bash
 confluent kafka topic create output-topic --partitions 1
 ```

--- a/_includes/tutorials/merging/confluent/markup/dev/run-classical-producer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-classical-producer.adoc
@@ -1,6 +1,6 @@
 To produce the classical songs, open up another terminal and run:
 
-```
+```bash
 confluent kafka topic produce classical-song-events \
     --value-format avro \
     --schema src/main/avro/song_event.avsc

--- a/_includes/tutorials/merging/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-consumer.adoc
@@ -1,6 +1,6 @@
 Leaving your original terminals running, open another to consume the events that have been merged:
 
-```
+```bash
 confluent kafka topic consume all-song-events \
       --from-beginning \
       --value-format avro

--- a/_includes/tutorials/merging/confluent/markup/dev/run-rock-producer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-rock-producer.adoc
@@ -1,6 +1,6 @@
 To produce the input events to their respective topics, you'll want two terminals running. To send the rock songs to their topic, open up a terminal and run the following:
 
-```
+```bash
 confluent kafka topic produce rock-song-events \
       --value-format avro \
       --schema src/main/avro/song_event.avsc

--- a/_includes/tutorials/multiple-event-types/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/multiple-event-types/confluent/markup/dev/make-topic.adoc
@@ -4,7 +4,7 @@ Since you are going to produce records using Protobuf and Avro serialization, yo
 
 Use the following commands to create the topics:
 
-```
+```bash
 confluent kafka topic create avro-events
 confluent kafka topic create proto-events
 ```

--- a/_includes/tutorials/optimize-producer-throughput/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/optimize-producer-throughput/confluent/markup/dev/make-topic.adoc
@@ -1,7 +1,7 @@
 In this step we’re going to create a topic for use during this tutorial.
 Use the following command to create the topic:
 
-```
+```bash
 confluent kafka topic create topic-perf
 ```
 

--- a/_includes/tutorials/session-windows/confluent/markup/dev/ccloud-run-consumer.adoc
+++ b/_includes/tutorials/session-windows/confluent/markup/dev/ccloud-run-consumer.adoc
@@ -1,6 +1,6 @@
 Now that your Kafka Streams application is running, open a new terminal window, change directories (`cd`) into the `session-windows` directory and start a console-consumer to confirm the output:
 
-```
+```bash
 confluent kafka topic consume output-topic --from-beginning --print-key
 ```
 

--- a/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-consumer.adoc
+++ b/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-consumer.adoc
@@ -2,7 +2,7 @@ Leave your original terminal running. To consume the output events from each of 
 
 First, to consume the events of drama films, run the following:
 
-```
+```bash
 confluent kafka topic consume drama-acting-events --from-beginning --value-format avro
 ```
 
@@ -14,7 +14,7 @@ This should yield the following messages:
 
 Second, to consume those from fantasy films, run the following:
 
-```
+```bash
 confluent kafka topic consume fantasy-acting-events --from-beginning --value-format avro
 ```
 
@@ -26,7 +26,7 @@ This should yield the following messages:
 
 And finally, to consume all the other genres, run the following:
 
-```
+```bash
  confluent kafka topic consume other-acting-events --from-beginning --value-format avro
 ```
 

--- a/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,6 +1,6 @@
 In a new terminal, run:
 
-```
+```bash
 confluent kafka topic produce acting-events --value-format avro --schema src/main/avro/acting_event.avsc
 ```
 


### PR DESCRIPTION
### Description

Fixes https://github.com/confluentinc/kafka-tutorials/issues/1356

Updated all bash code snippets to explicitly use bash syntax. Verified with local build.

[X] Validate presentation with `bundle exec jekyll serve --livereload`
