### PR TITLE
remove dupe properties explanation

### DIFF
--- a/_data/harnesses/kafka-consumer-application/confluent.yml
+++ b/_data/harnesses/kafka-consumer-application/confluent.yml
@@ -64,10 +64,6 @@ dev:
           render:
             file: shared/markup/ccloud/append-ccloud-config.adoc
 
-        - action: skip
-          render:
-            file: tutorials/kafka-consumer-application/kafka/markup/dev/explain-properties.adoc
-
     - title: Create the Kafka Consumer Application
       content:
         - action: execute


### PR DESCRIPTION
### Description

Fixes https://github.com/confluentinc/kafka-tutorials/issues/1358

Removed duplicate explanation of configuration properties in recipe. Checked all recipes for dupes. Validated change with local build.

[ ] Validate presentation with `bundle exec jekyll serve --livereload`
