### PR TITLE
Updating tutorials to use new shadowJar location.

### DIFF
--- a/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-    classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+    classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
   }
 }
 

--- a/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/filtering/kstreams/code/build.gradle
+++ b/_includes/tutorials/filtering/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-    classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+    classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
   }
 }
 

--- a/_includes/tutorials/finding-distinct/kstreams/code/build.gradle
+++ b/_includes/tutorials/finding-distinct/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-    classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+    classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
   }
 }
 

--- a/_includes/tutorials/fk-joins/kstreams/code/build.gradle
+++ b/_includes/tutorials/fk-joins/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-    classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+    classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
   }
 }
 

--- a/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+    classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }
 

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/build.gradle
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/merging/kstreams/code/build.gradle
+++ b/_includes/tutorials/merging/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/message-ordering/kafka/code/build.gradle
+++ b/_includes/tutorials/message-ordering/kafka/code/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
+++ b/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/code/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/session-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/session-windows/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/splitting/kstreams/code/build.gradle
+++ b/_includes/tutorials/splitting/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-    classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+    classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
   }
 }
 

--- a/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/time-concepts/ksql/code/build.gradle
+++ b/_includes/tutorials/time-concepts/ksql/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.21.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:4.0.2"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/_includes/tutorials/transforming/kafka/code/build.gradle
+++ b/_includes/tutorials/transforming/kafka/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+    classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }
 

--- a/_includes/tutorials/transforming/kstreams/code/build.gradle
+++ b/_includes/tutorials/transforming/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+    classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }
 

--- a/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
+    classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
   }
 }
 

--- a/_includes/tutorials/window-final-result/kstreams/code/build.gradle
+++ b/_includes/tutorials/window-final-result/kstreams/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.22.0"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.1.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 

--- a/templates/kstreams/filtered/code/build.gradle
+++ b/templates/kstreams/filtered/code/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.15.1"
-        classpath "com.github.jengelman.gradle.plugins:shadow:6.0.0"
+        classpath "gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0"
     }
 }
 


### PR DESCRIPTION
The location of the shadowJar Gradle plugin has moved, so I updated the pertinent line in the `build.gradle` file for all the tutorials that use shadowJar.  28 files were affected.