### PR TITLE
Navigation UI bug fixed for specific viewport width range

### DIFF
--- a/assets/sass/_nav.scss
+++ b/assets/sass/_nav.scss
@@ -1014,7 +1014,6 @@ a:hover {
   display: flex;
   flex-direction: column;
   background: $color_deepMeadow;
-  max-width: 290px;
   padding: 15px 30px;
 
   .icon {


### PR DESCRIPTION
### Description

- For viewport width (992-1100 px), the navigation header was taking only 290px width. (Screenshot-1)
- But, we want it to take full space available for that viewport width range.
- This PR does that with a one-liner CSS change (Screenshot-2)

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/99665800/190430467-e646d0b0-49ba-4773-84a5-5301060efd6b.png">

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/99665800/190430785-40e45c9a-c709-45d4-9d37-6d3d84488f64.png">


### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
