### PR TITLE
[DO NOT MERGE] use Semaphore cache to avoid docker image downloads per task

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,6 +17,29 @@ global_job_config:
           unzip ~/.gradle/gradle-7.5.1-bin.zip -d ~/.gradle
           cache store gradle-7.5.1 ~/.gradle
         fi
+      - |
+        if ! cache has_key cp-7.1.0-images; then
+          docker pull confluentinc/cp-kafka:7.1.0
+          docker pull confluentinc/cp-zookeeper:7.1.0
+          docker pull confluentinc/cp-schema-registry:7.1.0
+          docker pull confluentinc/cp-kafka-connect-base:7.1.0
+          docker pull confluentinc/cp-server-connect-base:7.1.0
+          docker pull confluentinc/ksqldb-server:0.24.0
+          docker pull confluentinc/ksqldb-cli:0.24.0
+          docker save confluentinc/cp-kafka:7.1.0 \
+                      confluentinc/cp-zookeeper:7.1.0 \
+                      confluentinc/cp-schema-registry:7.1.0 \
+                      confluentinc/cp-kafka-connect-base:7.1.0 \
+                      confluentinc/cp-server-connect-base:7.1.0 \
+                      confluentinc/ksqldb-server:0.24.0 \
+                      confluentinc/ksqldb-cli:0.24.0 \
+                      | gzip > cp.tar.gz
+          cache store cp-7.1.0-images cp.tar.gz
+          rm -f cp.tar.gz
+        else
+          docker image inspect confluentinc/cp-kafka:7.1.0 || \
+            (cache restore cp-7.1.0-images && docker load < cp.tar.gz && rm -f cp.tar.gz)
+        fi
       - cache restore gradle-7.5.1
       - sudo update-alternatives --install /usr/bin/gradle gradle ~/.gradle/gradle-7.5.1/bin/gradle 10
       - make install-vault

--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,6 @@ exclude:
   - tools/
 
 ak_javadoc_version: 23
-cp_version: v5.3.0
 google_tag_manager_id: GTM-M58HDC6
 
 plugins:


### PR DESCRIPTION
### Description

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
