### PR TITLE
BACKLOG: Cleaned up dependencies to include clients explicitly

### DIFF
--- a/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
@@ -30,7 +30,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "org.apache.kafka:kafka-clients:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
@@ -30,8 +30,8 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-clients:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }


### PR DESCRIPTION
### Description
The build script only contains a dependency for Kafka Streams.  The application works because KS pulls in the clients as a transitive dependency. Still, since the application does not use Kafka Streams, we should update the dependencies to pull in clients and remove the KS one explicitly.

Internal changes only to the `build.gradle` file no functional changes.

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
