### PR TITLE
update `docker-compose` commands to `docker compose`

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,6 +22,29 @@ global_job_config:
         fi
       - cache restore gradle-7.5.1
       - sudo update-alternatives --install /usr/bin/gradle gradle ~/.gradle/gradle-7.5.1/bin/gradle 10
+      - |
+        if ! cache has_key cp-7.1.0-images; then
+          docker pull confluentinc/cp-kafka:7.1.0
+          docker pull confluentinc/cp-zookeeper:7.1.0
+          docker pull confluentinc/cp-schema-registry:7.1.0
+          docker pull confluentinc/cp-kafka-connect-base:7.1.0
+          docker pull confluentinc/cp-server-connect-base:7.1.0
+          docker pull confluentinc/ksqldb-server:0.24.0
+          docker pull confluentinc/ksqldb-cli:0.24.0
+          docker save confluentinc/cp-kafka:7.1.0 \
+                      confluentinc/cp-zookeeper:7.1.0 \
+                      confluentinc/cp-schema-registry:7.1.0 \
+                      confluentinc/cp-kafka-connect-base:7.1.0 \
+                      confluentinc/cp-server-connect-base:7.1.0 \
+                      confluentinc/ksqldb-server:0.24.0 \
+                      confluentinc/ksqldb-cli:0.24.0 \
+                      | gzip > cp.tar.gz
+          cache store cp-7.1.0-images cp.tar.gz
+          rm -f cp.tar.gz
+        else
+          docker image inspect confluentinc/cp-kafka:7.1.0 || \
+            (cache restore cp-7.1.0-images && docker load < cp.tar.gz && rm -f cp.tar.gz)
+        fi
       - make install-vault
       - . vault-bin/vault-setup
       - . vault-sem-get-secret aws_credentials

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you are interested in testing tutorials locally see the [Testing Locally](#te
 - npm
 - python3 / pip3
 - gradle
-- docker-compose
+- [Docker Compose](https://docs.docker.com/compose/)
 
 On the Mac, you can get the dependencies like this:
 
@@ -293,7 +293,7 @@ The following prerequisites are required if you are going to run a tutorial prog
 
 - python3 / pip3
 - gradle
-- docker-compose
+- [Docker Compose](https://docs.docker.com/compose/)
 
 ### Environment Setup
 
@@ -352,7 +352,7 @@ export COMPOSE_FILE=docker-compose.yml:<path to tutorials>/tools/docker-compose.
 Now you can play with the environment, some sample commands shown below.
 
 ```
-docker exec broker kafka-topics --list --bootstrap-server localhost:9092
+docker exec -t broker kafka-topics --list --bootstrap-server localhost:9092
 docker exec -it ksqldb-cli ksql http://ksqldb-server:8088               
 ```
 
@@ -508,7 +508,7 @@ In the next sections, you'll see how to use `action` keys to organize your harne
 
 * `execute_async` The `execute_async` step is for steps needing to execute in the background while the user continues going through the tutorial
   
-     Here's an example of running `docker-compose` to start docker containers to run the duration of the tutorial
+     Here's an example of running `docker compose` to start docker containers to run the duration of the tutorial
      
      ```yml
       - action: execute_async

--- a/_data/harnesses/concatenation/ksql.yml
+++ b/_data/harnesses/concatenation/ksql.yml
@@ -80,8 +80,6 @@ dev:
         - action: docker_ksql_cli_session
           container: ksqldb-cli
           docker_bootup_file: tutorial-steps/dev/start-cli.sh
-          stdout:
-            directory: tutorial-steps/dev/outputs
           column_width: 50
           render:
             skip: true

--- a/_data/harnesses/confluent-parallel-consumer-application/kafka.yml
+++ b/_data/harnesses/confluent-parallel-consumer-application/kafka.yml
@@ -107,6 +107,12 @@ dev:
           render:
             file: tutorials/confluent-parallel-consumer-application/kafka/markup/dev/run-producer.adoc
 
+        - name: wait for producer
+          action: sleep
+          ms: 5000
+          render:
+            skip: true
+
     - title: Inspect the consumed records
       content:
         - action: execute

--- a/_data/harnesses/kafka-connect-datagen/kafka.yml
+++ b/_data/harnesses/kafka-connect-datagen/kafka.yml
@@ -39,7 +39,7 @@ dev:
 
         - name: give Kafka Connect chance to create the connector
           action: sleep
-          ms: 5000
+          ms: 10000
           render:
             skip: true
 
@@ -51,7 +51,7 @@ dev:
 
         - name: give Kafka Connect further chance to get the data to the topic
           action: sleep
-          ms: 5000
+          ms: 10000
           render:
             skip: true
 

--- a/_data/harnesses/kafka-consumer-application/kafka.yml
+++ b/_data/harnesses/kafka-consumer-application/kafka.yml
@@ -102,6 +102,12 @@ dev:
           render:
             file: tutorials/kafka-consumer-application/kafka/markup/dev/run-producer.adoc
 
+        - name: wait for producer
+          action: sleep
+          ms: 5000
+          render:
+            skip: true
+
     - title: Inspect the consumed records
       content:
         - action: execute

--- a/_includes/tutorials/SSH-attack/confluent/markup/dev/source.adoc
+++ b/_includes/tutorials/SSH-attack/confluent/markup/dev/source.adoc
@@ -23,7 +23,7 @@ Run the container with this:
 
 [source,text]
 ----
-docker-compose up -d
+docker compose up -d
 ----
 
 Create a Syslog Source connector configuration file called `connector-syslog.config`:

--- a/_includes/tutorials/SSH-attack/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/SSH-attack/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/aggregating-average/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-average/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/aggregating-average/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/aggregating-average/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/aggregating-count/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-count/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/aggregating-count/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/aggregating-count/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/aggregating-count/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/aggregating-minmax/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-minmax/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/aggregating-minmax/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/aggregating-minmax/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/aggregating-sum/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-sum/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/aggregating-sum/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/aggregating-sum/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/aggregating-sum/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/aggregating-sum/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/anomaly-detection/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/anomaly-detection/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/anomaly-detection/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/anomaly-detection/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/audit-logs/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/audit-logs/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/aviation/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/aviation/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/campaign-finance/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/campaign-finance/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/test/consume-data-input.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/test/consume-data-input.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
   --bootstrap-server localhost:9092 \
   --topic topic1 \
   --property print.key=true \

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/test/consume-data-output-partition-0.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/test/consume-data-output-partition-0.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
   --bootstrap-server localhost:9092 \
   --topic topic2 \
   --property print.key=true \

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/test/consume-data-output-partition-1.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/test/consume-data-output-partition-1.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
   --bootstrap-server localhost:9092 \
   --topic topic2 \
   --property print.key=true \

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/test/produce-data-input.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/test/produce-data-input.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-producer \
+docker exec -i broker kafka-console-producer \
   --bootstrap-server localhost:9092 \
   --topic topic1 \
   --property parse.key=true \

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/create-topic.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --bootstrap-server broker:9092 --topic topic1 --create --replication-factor 1 --partitions 1
+docker exec -it broker kafka-topics --bootstrap-server broker:9092 --topic topic1 --create --replication-factor 1 --partitions 1

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/describe-new-topic.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/describe-new-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --bootstrap-server broker:9092 --topic topic2 --describe
+docker exec -t broker kafka-topics --bootstrap-server broker:9092 --topic topic2 --describe

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/describe-original-topic.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/describe-original-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --bootstrap-server broker:9092 --topic topic1 --describe
+docker exec -t broker kafka-topics --bootstrap-server broker:9092 --topic topic1 --describe

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/test/harness-console-consumer-topic1-partition-0.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/test/harness-console-consumer-topic1-partition-0.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-console-consumer --bootstrap-server localhost:9092 --topic topic1 --property print.key=true --property key.separator=, --partition 0 --from-beginning  --max-messages 12
+docker exec -t broker kafka-console-consumer --bootstrap-server localhost:9092 --topic topic1 --property print.key=true --property key.separator=, --partition 0 --from-beginning  --max-messages 12

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/test/harness-console-consumer-topic2-partition-0.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/test/harness-console-consumer-topic2-partition-0.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-console-consumer --bootstrap-server localhost:9092 --topic topic2 --property print.key=true --property key.separator=, --partition 0 --from-beginning  --max-messages 9
+docker exec -t broker kafka-console-consumer --bootstrap-server localhost:9092 --topic topic2 --property print.key=true --property key.separator=, --partition 0 --from-beginning  --max-messages 9

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/test/harness-console-consumer-topic2-partition-1.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/test/harness-console-consumer-topic2-partition-1.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-console-consumer --bootstrap-server localhost:9092 --topic topic2 --property print.key=true --property key.separator=, --partition 1 --from-beginning  --max-messages 3
+docker exec -t broker kafka-console-consumer --bootstrap-server localhost:9092 --topic topic2 --property print.key=true --property key.separator=, --partition 1 --from-beginning  --max-messages 3

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/test/harness-console-producer.sh
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/tutorial-steps/test/harness-console-producer.sh
@@ -1,1 +1,1 @@
-docker-compose exec -T broker kafka-console-producer --bootstrap-server localhost:9092 --topic topic1 --property parse.key=true --property key.separator=,
+docker exec -i broker kafka-console-producer --bootstrap-server localhost:9092 --topic topic1 --property parse.key=true --property key.separator=,

--- a/_includes/tutorials/clickstream/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/clickstream/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/column-difference/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/column-difference/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/column-difference/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/column-difference/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/concatenation/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/concatenation/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/concatenation/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/concatenation/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/harness-console-producer.sh
+++ b/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/harness-console-producer.sh
@@ -1,1 +1,1 @@
-docker-compose exec -T broker kafka-console-producer --topic parallel-consumer-input-topic --bootstrap-server broker:9092 --property "parse.key=true" --property "key.separator=:"
+docker exec -i broker kafka-console-producer --topic parallel-consumer-input-topic --bootstrap-server broker:9092 --property "parse.key=true" --property "key.separator=:"

--- a/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/harness-create-topic.sh
+++ b/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/harness-create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --create --topic example-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1
+docker exec -t broker kafka-topics --create --topic example-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1

--- a/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec -it broker bash

--- a/_includes/tutorials/connect-add-key-to-source/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/connect-add-key-to-source/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d --build
+docker compose up -d --build

--- a/_includes/tutorials/connect-add-key-to-source/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/connect-add-key-to-source/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/connect-add-key-to-source/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/connect-add-key-to-source/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down && docker rm -f $(docker ps -q --filter name=sqlitekt)
+docker compose down && docker rm -f $(docker ps -q --filter name=sqlitekt)

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d --build
+docker compose up -d --build

--- a/_includes/tutorials/connect-sink-timestamp/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/connect-sink-timestamp/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/connect-sink-timestamp/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/connect-sink-timestamp/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/harness-console-consumer-keys-deserializers.sh
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/harness-console-consumer-keys-deserializers.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic example --bootstrap-server broker:9092 \
+docker exec -t broker kafka-console-consumer --topic example --bootstrap-server broker:9092 \
  --from-beginning \
  --property print.key=true \
  --property key.separator=" : " \

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic example --bootstrap-server broker:9092 \
+docker exec -t broker kafka-console-consumer --topic example --bootstrap-server broker:9092 \
  --from-beginning \
  --property print.key=true \
  --property key.separator=" : " \

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec -it broker bash

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/markup/dev/start-compose.adoc
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/markup/dev/start-compose.adoc
@@ -4,6 +4,6 @@ And launch it by running:
 <pre class="snippet"><code class="shell">{% include_raw tutorials/console-consumer-primitive-keys-values/kafka/code/tutorial-steps/dev/docker-compose-up.sh %}</code></pre>
 +++++
 
-After you've ran the `docker-compose up -d` command, wait 30 seconds to a 1 minute before executing the next step.
+After you've run the `docker compose up -d` command, wait 30 seconds to a 1 minute before executing the next step.
 
 

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/create-topic.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --create --topic orders-avro --bootstrap-server broker:9092
+docker exec -t broker kafka-topics --create --topic orders-avro --bootstrap-server broker:9092

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-consumer-from-beginning.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-consumer-from-beginning.sh
@@ -1,4 +1,4 @@
-docker-compose exec -T schema-registry kafka-avro-console-consumer \
+docker exec -t schema-registry kafka-avro-console-consumer \
   --topic orders-avro \
   --bootstrap-server broker:9092 \
   --property schema.registry.url=http://localhost:8081 \

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
@@ -1,4 +1,4 @@
-docker-compose exec -T schema-registry kafka-avro-console-consumer \
+docker exec -t schema-registry kafka-avro-console-consumer \
   --topic orders-avro \
   --property schema.registry.url=http://localhost:8081 \
   --bootstrap-server broker:9092 \

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec -T schema-registry kafka-avro-console-consumer \
+docker exec -t schema-registry kafka-avro-console-consumer \
   --topic orders-avro \
   --bootstrap-server broker:9092 \
   --property schema.registry.url=http://localhost:8081 \

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-producer-keys.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-producer-keys.sh
@@ -1,4 +1,4 @@
-docker-compose exec -T schema-registry kafka-avro-console-producer \
+docker exec -i schema-registry kafka-avro-console-producer \
   --topic orders-avro \
   --bootstrap-server broker:9092 \
   --property schema.registry.url=http://localhost:8081 \

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-producer.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/harness-console-producer.sh
@@ -1,4 +1,4 @@
-docker-compose exec -T schema-registry kafka-avro-console-producer \
+docker exec -i schema-registry kafka-avro-console-producer \
   --topic orders-avro \
   --bootstrap-server broker:9092 \
   --property schema.registry.url=http://localhost:8081 \

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec schema-registry bash
+docker exec schema-registry bash

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/create-topic.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --create --topic orders --bootstrap-server broker:9092
+docker exec -t broker kafka-topics --create --topic orders --bootstrap-server broker:9092

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer-from-beginning.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer-from-beginning.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
   --topic orders \
   --bootstrap-server broker:9092 \
   --from-beginning \

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
  --topic orders \
  --bootstrap-server broker:9092 \
  --from-beginning \

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
   --topic orders \
   --bootstrap-server broker:9092 \
   --max-messages 4

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-producer-keys.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-producer-keys.sh
@@ -1,4 +1,4 @@
-docker-compose exec -T broker kafka-console-producer \
+docker exec -i broker kafka-console-producer \
   --topic orders \
   --bootstrap-server broker:9092 \
   --property parse.key=true \

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-producer.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/harness-console-producer.sh
@@ -1,3 +1,3 @@
-docker-compose exec -T broker kafka-console-producer \
+docker exec -i broker kafka-console-producer \
   --topic orders \
   --bootstrap-server broker:9092

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec broker bash

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-console-consumer-keys-partition-one-offset-six.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-console-consumer-keys-partition-one-offset-six.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 \
+docker exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 \
  --property print.key=true \
  --property key.separator="-" \
  --partition 1 \

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-console-consumer-keys-partition-one.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-console-consumer-keys-partition-one.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 \
+docker exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 \
  --from-beginning \
  --property print.key=true \
  --property key.separator="-" \

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-console-consumer-keys-partition-zero.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-console-consumer-keys-partition-zero.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 \
+docker exec broker kafka-console-consumer --topic example-topic --bootstrap-server broker:9092 \
  --from-beginning \
  --property print.key=true \
  --property key.separator="-" \

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-console-producer-keys.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-console-producer-keys.sh
@@ -1,3 +1,3 @@
-docker-compose exec -T broker kafka-console-producer --topic example-topic --bootstrap-server broker:9092 \
+docker exec -i broker kafka-console-producer --topic example-topic --bootstrap-server broker:9092 \
   --property parse.key=true \
   --property key.separator=":"

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-create-topic.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/harness-create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --create --topic example-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 2
+docker exec broker kafka-topics --create --topic example-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 2

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec broker bash

--- a/_includes/tutorials/count-messages/kafka/code/Makefile
+++ b/_includes/tutorials/count-messages/kafka/code/Makefile
@@ -19,4 +19,4 @@ tutorial_main:
 
 cleanup:
 	cd $(TEMP_DIR)
-	docker-compose down
+	docker compose down

--- a/_includes/tutorials/count-messages/kafka/code/tutorial-steps/dev/02b-docker-compose-up.sh
+++ b/_includes/tutorials/count-messages/kafka/code/tutorial-steps/dev/02b-docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/count-messages/kafka/code/tutorial-steps/dev/05-clean-up.sh
+++ b/_includes/tutorials/count-messages/kafka/code/tutorial-steps/dev/05-clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/count-messages/ksql/code/Makefile
+++ b/_includes/tutorials/count-messages/ksql/code/Makefile
@@ -24,4 +24,4 @@ tutorial_main:
 
 cleanup:
 	cd $(TEMP_DIR)
-	docker-compose down
+	docker compose down

--- a/_includes/tutorials/count-messages/ksql/code/tutorial-steps/dev/02b-docker-compose-up.sh
+++ b/_includes/tutorials/count-messages/ksql/code/tutorial-steps/dev/02b-docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/count-messages/ksql/code/tutorial-steps/test/03-clean-up.sh
+++ b/_includes/tutorials/count-messages/ksql/code/tutorial-steps/test/03-clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/markup/dev/run-consumer.adoc
@@ -26,4 +26,4 @@ You should see output events that are entirely upper case:
 
 Once you are done with observing the behavior of the application, stop the consumers and the Kafka Streams application with `ctrl-c` in the appropriate terminal windows.
 
-Finally, shutdown Confluent Platform by invoking `docker-compose down -v`.
+Finally, shutdown Confluent Platform by invoking `docker compose down -v`.

--- a/_includes/tutorials/credit-card-activity/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/credit-card-activity/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/customer-journey/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/customer-journey/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/datacenter/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/datacenter/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/ddos/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/ddos/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/denormalization/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/denormalization/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/deserialization-errors/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/deserialization-errors/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/deserialization-errors/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/deserialization-errors/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/discount-promo/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/discount-promo/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/dynamic-pricing/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/dynamic-pricing/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/error-handling/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/error-handling/confluent/markup/dev/run-consumer.adoc
@@ -4,7 +4,7 @@
 
 ////
 
-Now that you've ran the Kafka Streams application, it should have shut itself down due to reaching the max-error threshold.
+Now that you've run the Kafka Streams application, it should have shut itself down due to reaching the max-error threshold.
 
 Let's now run the Confluent CLI to confirm the output:
 

--- a/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
  --bootstrap-server broker:9092 \
  --topic output-topic \
  --from-beginning \

--- a/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/error-handling/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/error-handling/kstreams/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/error-handling/kstreams/markup/dev/run-consumer.adoc
@@ -4,7 +4,7 @@
 
 ////
 
-Now that you've ran the Kafka Streams application, it should have shut it self down due to reaching the max-error threshold.
+Now that you've run the Kafka Streams application, it should have shut it self down due to reaching the max-error threshold.
 
 Let's now run the `kafka-console-consumer` to confirm the output:
 

--- a/_includes/tutorials/filtering/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/filtering/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/filtering/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/filtering/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/filtering/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/filtering/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/filtering/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/filtering/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/finding-distinct/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/finding-distinct/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/finding-distinct/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/finding-distinct/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/finding-distinct/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/finding-distinct/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/finding-distinct/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/finding-distinct/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/firewall-splunk/confluent/markup/dev/source.adoc
+++ b/_includes/tutorials/firewall-splunk/confluent/markup/dev/source.adoc
@@ -25,7 +25,7 @@ Run the container with the Connect worker:
 
 [source,text]
 ----
-docker-compose up -d
+docker compose up -d
 ----
 
 Create a configuration file, `connector-splunk-s2s.config`, for the Splunk S2S Source connector, specifying the port that the connector will use:

--- a/_includes/tutorials/firewall-splunk/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/firewall-splunk/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/fk-joins/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/fk-joins/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/fk-joins/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/fk-joins/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/flatten-nested-data/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/flatten-nested-data/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/flatten-nested-data/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/flatten-nested-data/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/fleet-management/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/fleet-management/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/generate-test-data-streams/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/generate-test-data-streams/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/generate-test-data-streams/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/generate-test-data-streams/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/generate-test-data-streams/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/geo-distance/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/geo-distance/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/geo-distance/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/geo-distance/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/hopping-windows/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/hopping-windows/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/hopping-windows/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/hopping-windows/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/internet-of-things/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/internet-of-things/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/inventory/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/inventory/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/iot-asset-tracking/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/iot-asset-tracking/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/joining-stream-stream/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/joining-stream-stream/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/joining-stream-stream/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/joining-stream-stream/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/joining-stream-table/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/joining-stream-table/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/joining-stream-table/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/joining-stream-table/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/joining-stream-table/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/joining-stream-table/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/joining-table-table/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/joining-table-table/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/joining-table-table/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/joining-table-table/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/kafka-connect-datagen/confluent/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d --build
+docker compose up -d --build

--- a/_includes/tutorials/kafka-connect-datagen/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/kafka-connect-datagen/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/kafka-connect-datagen/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/kafka-connect-datagen/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d --build
+docker compose up -d --build

--- a/_includes/tutorials/kafka-connect-datagen/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
+++ b/_includes/tutorials/kafka-connect-datagen/kafka/code/tutorial-steps/dev/harness-console-consumer-keys.sh
@@ -1,4 +1,4 @@
-docker-compose exec connect kafka-avro-console-consumer \
+docker exec -it connect kafka-avro-console-consumer \
  --bootstrap-server broker:9092 \
  --property schema.registry.url=http://schema-registry:8081 \
  --topic pageviews \

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/harness-console-producer.sh
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/harness-console-producer.sh
@@ -1,1 +1,1 @@
-docker-compose exec -T broker kafka-console-producer --topic input-topic --bootstrap-server broker:9092
+docker exec -i broker kafka-console-producer --topic input-topic --bootstrap-server broker:9092

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/harness-create-topic.sh
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/harness-create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --create --topic example-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1
+docker exec -t broker kafka-topics --create --topic example-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec broker bash

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/prod/clean-up.sh
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/tutorial-steps/prod/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down --volumes
+docker compose down --volumes

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic output-topic --bootstrap-server broker:9092 \
+docker exec -t broker kafka-console-consumer --topic output-topic --bootstrap-server broker:9092 \
  --from-beginning \
  --property print.key=true \
  --property key.separator=" : "

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/harness-create-topic.sh
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/harness-create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --create --topic output-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1
+docker exec -t broker kafka-topics --create --topic output-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec -it broker bash

--- a/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/harness-console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic output-topic --bootstrap-server broker:9092 \
+docker exec -t broker kafka-console-consumer --topic output-topic --bootstrap-server broker:9092 \
  --from-beginning \
  --property print.key=true \
  --property key.separator=" : "

--- a/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/harness-create-topic.sh
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/harness-create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --create --topic output-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1
+docker exec -t broker kafka-topics --create --topic output-topic --bootstrap-server broker:9092 --replication-factor 1 --partitions 1

--- a/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec broker bash

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/tutorial-steps/dev/console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
  --bootstrap-server broker:9092 \
  --topic output-topic \
  --property print.key=true \

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d --build
+docker compose up -d --build

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/tutorial-steps/dev/wait-for-datagen-topic.sh
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/tutorial-steps/dev/wait-for-datagen-topic.sh
@@ -2,7 +2,7 @@
 
 # Wait for the datagen topic to be created
 while : 
-  do output=$(docker-compose exec broker kafka-topics --bootstrap-server localhost:29092 --topic login-events --describe)
+  do output=$(docker exec -t broker kafka-topics --bootstrap-server localhost:29092 --topic login-events --describe)
   if [[ "$output" =~ "Topic: login-events" ]]; then
     echo "Topic login-events exists"
     break

--- a/_includes/tutorials/ksql-heterogeneous-json/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/ksql-heterogeneous-json/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/ksql-heterogeneous-json/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/ksql-heterogeneous-json/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/ksql-nested-json/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/ksql-nested-json/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/ksql-nested-json/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/ksql-nested-json/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/location-based-alerting/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/location-based-alerting/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/logistics/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/logistics/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/loyalty-rewards/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/loyalty-rewards/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/mainframe-offload/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/mainframe-offload/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/masking-data/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/masking-data/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/masking-data/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/masking-data/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/merging/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/merging/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/merging/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/merging/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/merging/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/merging/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/merging/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/merging/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/dev/create-topic.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/dev/create-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --bootstrap-server broker:9092 --topic myTopic --create --replication-factor 1 --partitions 2
+docker exec -t broker kafka-topics --bootstrap-server broker:9092 --topic myTopic --create --replication-factor 1 --partitions 2

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/dev/describe-original-topic.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/dev/describe-original-topic.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-topics --bootstrap-server broker:9092 --topic myTopic --describe
+docker exec -t broker kafka-topics --bootstrap-server broker:9092 --topic myTopic --describe

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/console-consumer.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic myTopic \
+docker exec -t broker kafka-console-consumer --topic myTopic \
  --bootstrap-server broker:9092 \
  --from-beginning \
  --property print.key=true \

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/consume-data-input-partition-0.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/consume-data-input-partition-0.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
   --bootstrap-server localhost:9092 \
   --topic myTopic \
   --property print.key=true \

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/consume-data-input-partition-1.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/consume-data-input-partition-1.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
   --bootstrap-server localhost:9092 \
   --topic myTopic \
   --property print.key=true \

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/dump-log-segments-0.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/dump-log-segments-0.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-dump-log \
+docker exec -t broker kafka-dump-log \
   --print-data-log \
   --files '/var/lib/kafka/data/myTopic-0/00000000000000000000.log' \
   --deep-iteration

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/dump-log-segments-1.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/dump-log-segments-1.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-dump-log \
+docker exec -t broker kafka-dump-log \
   --print-data-log \
   --files '/var/lib/kafka/data/myTopic-1/00000000000000000000.log' \
   --deep-iteration

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/harness-console-consumer-myTopic-partition-0.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/harness-console-consumer-myTopic-partition-0.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-console-consumer --bootstrap-server localhost:9092 --topic myTopic --property print.key=true --property key.separator=, --partition 0 --from-beginning
+docker exec -t broker kafka-console-consumer --bootstrap-server localhost:9092 --topic myTopic --property print.key=true --property key.separator=, --partition 0 --from-beginning

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/harness-console-consumer-myTopic-partition-1.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/harness-console-consumer-myTopic-partition-1.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker kafka-console-consumer --bootstrap-server localhost:9092 --topic myTopic --property print.key=true --property key.separator=, --partition 1 --from-beginning
+docker exec -t broker kafka-console-consumer --bootstrap-server localhost:9092 --topic myTopic --property print.key=true --property key.separator=, --partition 1 --from-beginning

--- a/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/produce-data-input.sh
+++ b/_includes/tutorials/message-ordering/kafka/code/tutorial-steps/test/produce-data-input.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-producer \
+docker exec -i broker kafka-console-producer \
   --bootstrap-server localhost:9092 \
   --topic myTopic \
   --property parse.key=true \

--- a/_includes/tutorials/messaging-modernization/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/messaging-modernization/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/model-retraining/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/model-retraining/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/multi-joins/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/multi-joins/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/multi-joins/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/multi-joins/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/dev/harness-create-topic.sh
+++ b/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/dev/harness-create-topic.sh
@@ -1,2 +1,2 @@
-docker-compose exec broker kafka-topics --create --topic proto-events --bootstrap-server broker:9092 --replication-factor 1 --partitions 1
-docker-compose exec broker kafka-topics --create --topic avro-events --bootstrap-server broker:9092 --replication-factor 1 --partitions 1
+docker exec -t broker kafka-topics --create --topic proto-events --bootstrap-server broker:9092 --replication-factor 1 --partitions 1
+docker exec -t broker kafka-topics --create --topic avro-events --bootstrap-server broker:9092 --replication-factor 1 --partitions 1

--- a/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec broker bash

--- a/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/prod/clean-up.sh
+++ b/_includes/tutorials/multiple-event-types/kafka/code/tutorial-steps/prod/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down --volumes
+docker compose down --volumes

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/next-best-offer/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/next-best-offer/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/omnichannel-commerce/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/omnichannel-commerce/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/online-dating/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/online-dating/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/payment-status-check/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/payment-status-check/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/produce-consume-lang/scala/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/produce-consume-lang/scala/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/produce-consume-lang/scala/code/tutorial-steps/prod/clean-up.sh
+++ b/_includes/tutorials/produce-consume-lang/scala/code/tutorial-steps/prod/clean-up.sh
@@ -1,3 +1,3 @@
 docker rm -f tutorial-consumer tutorial-producer
-docker-compose down
+docker compose down
 

--- a/_includes/tutorials/rekeying-function/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/rekeying-function/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/rekeying-function/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/rekeying-function/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/salesforce/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/salesforce/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/serialization/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/serialization/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/serialization/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/serialization/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/serialization/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/serialization/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/serialization/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/serialization/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/session-windows/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/session-windows/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/session-windows/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/session-windows/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/session-windows/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/session-windows/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/session-windows/kstreams/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/session-windows/kstreams/code/tutorial-steps/dev/console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
  --bootstrap-server broker:9092 \
  --topic output-topic \
  --property print.key=true \

--- a/_includes/tutorials/session-windows/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/session-windows/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/sliding-windows/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/sliding-windows/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/sliding-windows/kstreams/code/tutorial-steps/dev/console-consumer.sh
+++ b/_includes/tutorials/sliding-windows/kstreams/code/tutorial-steps/dev/console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer \
+docker exec -t broker kafka-console-consumer \
  --bootstrap-server broker:9092 \
  --topic output-topic \
  --property print.key=true \

--- a/_includes/tutorials/sliding-windows/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/sliding-windows/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d --build
+docker compose up -d --build

--- a/_includes/tutorials/sliding-windows/kstreams/code/tutorial-steps/dev/wait-for-datagen-topic.sh
+++ b/_includes/tutorials/sliding-windows/kstreams/code/tutorial-steps/dev/wait-for-datagen-topic.sh
@@ -2,7 +2,7 @@
 
 # Wait for the datagen topic to be created
 while : 
-  do output=$(docker-compose exec broker kafka-topics --bootstrap-server localhost:29092 --topic temp-readings --describe)
+  do output=$(docker exec -t broker kafka-topics --bootstrap-server localhost:29092 --topic temp-readings --describe)
   if [[ "$output" =~ "Topic: temp-readings" ]]; then
     echo "Topic temp-readings exists"
     break

--- a/_includes/tutorials/splitting/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/splitting/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/splitting/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/splitting/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/splitting/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/splitting/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/splitting/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/splitting/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down --volumes
+docker compose down --volumes

--- a/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/harness-console-producer.sh
+++ b/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/harness-console-producer.sh
@@ -1,3 +1,3 @@
-docker-compose exec -T broker kafka-console-producer --topic input-topic --bootstrap-server broker:9092 \
+docker exec -i broker kafka-console-producer --topic input-topic --bootstrap-server broker:9092 \
   --property parse.key=true \
   --property key.separator=":"

--- a/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/harness-streams-console-consumer.sh
+++ b/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/harness-streams-console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic streams-output-topic --bootstrap-server broker:9092 \
+docker exec -t broker kafka-console-consumer --topic streams-output-topic --bootstrap-server broker:9092 \
 --from-beginning \
 --property print.key=true \
 --property key.separator=" - "

--- a/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/harness-table-console-consumer.sh
+++ b/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/harness-table-console-consumer.sh
@@ -1,4 +1,4 @@
-docker-compose exec broker kafka-console-consumer --topic table-output-topic --bootstrap-server broker:9092 \
+docker exec -t broker kafka-console-consumer --topic table-output-topic --bootstrap-server broker:9092 \
 --from-beginning \
 --property print.key=true \
 --property key.separator=" - "

--- a/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/open-docker-shell.sh
+++ b/_includes/tutorials/streams-to-table/kstreams/code/tutorial-steps/dev/open-docker-shell.sh
@@ -1,1 +1,1 @@
-docker-compose exec broker bash
+docker exec broker bash

--- a/_includes/tutorials/survey-responses/ksql-test/code/docker-compose-up.sh
+++ b/_includes/tutorials/survey-responses/ksql-test/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/time-concepts/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/time-concepts/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/time-concepts/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/time-concepts/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/transforming/kafka/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/transforming/kafka/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/transforming/kafka/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/transforming/kafka/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/transforming/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/transforming/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/transforming/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/transforming/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/transforming/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/transforming/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/transforming/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/transforming/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/tumbling-windows/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/tumbling-windows/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/tumbling-windows/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/tumbling-windows/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/udf/ksql/code/tutorial-steps/dev/clean-up.sh
+++ b/_includes/tutorials/udf/ksql/code/tutorial-steps/dev/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/_includes/tutorials/udf/ksql/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/udf/ksql/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/window-final-result/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
+++ b/_includes/tutorials/window-final-result/kstreams/code/tutorial-steps/dev/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/_includes/tutorials/window-final-result/kstreams/code/tutorial-steps/prod/clean-up.sh
+++ b/_includes/tutorials/window-final-result/kstreams/code/tutorial-steps/prod/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/templates/ksql/static/dev/code/clean-up.sh
+++ b/templates/ksql/static/dev/code/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/templates/ksql/static/dev/code/docker-compose-up.sh
+++ b/templates/ksql/static/dev/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d

--- a/templates/kstreams/static/dev/code/clean-up.sh
+++ b/templates/kstreams/static/dev/code/clean-up.sh
@@ -1,1 +1,1 @@
-docker-compose down
+docker compose down

--- a/templates/kstreams/static/dev/code/docker-compose-up.sh
+++ b/templates/kstreams/static/dev/code/docker-compose-up.sh
@@ -1,1 +1,1 @@
-docker-compose up -d
+docker compose up -d


### PR DESCRIPTION
### Description

docker compose [asana](https://app.asana.com/0/1201906632362444/1203191375670049/f)
docker image caching [asana](https://app.asana.com/0/1201906632362444/1203033929869384/f)

I made these changes together since the docker compose change added quite a bit of extraneous logging during image download.

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/docker-compose-command/
