### PR TITLE
MINOR: Changes for reducing friction on avro tutorial

### DIFF
--- a/_includes/tutorials/console-consumer-producer-avro/confluent/code/tutorial-steps/dev/harness-console-consumer-keys.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/confluent/code/tutorial-steps/dev/harness-console-consumer-keys.sh
@@ -1,1 +1,1 @@
-confluent kafka topic consume orders-avro --value-format avro --print-key --delimiter ":"
+confluent kafka topic consume orders-avro --value-format avro --print-key --delimiter "-"  --from-beginning

--- a/_includes/tutorials/console-consumer-producer-avro/confluent/markup/dev/consume-topic-key-value.adoc
+++ b/_includes/tutorials/console-consumer-producer-avro/confluent/markup/dev/consume-topic-key-value.adoc
@@ -1,6 +1,6 @@
 Next, let's open up a consumer to read records from the new topic. 
 
-From the same terminal you used to create the topic above, run the following command to start a console consumer with the `ccloud` CLI:
+From the same terminal you used to create the topic above, run the following command to start a console consumer with the `confluent` CLI:
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/console-consumer-producer-avro/confluent/code/tutorial-steps/dev/harness-console-consumer-keys.sh %}</code></pre>

--- a/_includes/tutorials/console-consumer-producer-avro/confluent/markup/dev/create-schema.adoc
+++ b/_includes/tutorials/console-consumer-producer-avro/confluent/markup/dev/create-schema.adoc
@@ -1,4 +1,4 @@
-We are going to use the https://docs.confluent.io/platform/current/schema-registry/schema_registry_ccloud_tutorial.html#sr-ccloud-tutorial[Confluent Cloud managed Schema Registry] to control our record format. The first step is creating a schema definition which we will use when producing new records.
+We are going to use https://docs.confluent.io/platform/current/schema-registry/index.html[Schema Registry] (managed by Confluent Cloud) to control our record format. The first step is creating a schema definition which we will use when producing new records.
 
 Create the following `orders-avro-schema.json` file: 
 

--- a/_includes/tutorials/console-consumer-producer-avro/confluent/markup/dev/produce-topic-key-value.adoc
+++ b/_includes/tutorials/console-consumer-producer-avro/confluent/markup/dev/produce-topic-key-value.adoc
@@ -12,7 +12,7 @@ The producer will start with some information and then wait for you to enter inp
 
 Below are example records in JSON format with each line representing a single record. In this case we are producing records in Avro format, however, first they are passed to the producer in JSON and the producer converts them to Avro based on the `orders-avro-schema.json` schema prior to sending them to Kafka.
 
-Copy each line and paste it into the producer terminal, pressing enter after each one to produce the new record. 
+Copy each line and paste it into the producer terminal, or copy-paste all of them into the terminal and hit enter.
 
 +++++
 <pre class="snippet"><code class="shell">{% include_raw tutorials/console-consumer-producer-avro/confluent/code/tutorial-steps/dev/records.txt %}</code></pre>


### PR DESCRIPTION
### Description

Small changes to correct the CLI console consumer tutorial

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
When the build completes:

 http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/USERBACK_friction_points_for_avro_consumer/kafka-console-consumer-producer-avro/confluent.html

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
