### PR TITLE
USERBACK: Add details about types with KStream merge

### DIFF
--- a/_includes/tutorials/merging/kstreams/markup/dev/make-topology.adoc
+++ b/_includes/tutorials/merging/kstreams/markup/dev/make-topology.adoc
@@ -3,3 +3,5 @@ Then create the following file at `src/main/java/io/confluent/developer/MergeStr
 +++++
 <pre class="snippet"><code class="java">{% include_raw tutorials/merging/kstreams/code/src/main/java/io/confluent/developer/MergeStreams.java %}</code></pre>
 +++++
+
+Note when using the `merge` operator the keys and values of the two `KStream` objects you're merging must be of the same type.  If you have 2 `KStream` instances with different key and/or value types, you'll have to use the `KStream.map` (or `KStream.mapValues`) to get the types to line-up before merging.

--- a/_includes/tutorials/merging/kstreams/markup/dev/make-topology.adoc
+++ b/_includes/tutorials/merging/kstreams/markup/dev/make-topology.adoc
@@ -4,4 +4,4 @@ Then create the following file at `src/main/java/io/confluent/developer/MergeStr
 <pre class="snippet"><code class="java">{% include_raw tutorials/merging/kstreams/code/src/main/java/io/confluent/developer/MergeStreams.java %}</code></pre>
 +++++
 
-Note when using the `merge` operator the keys and values of the two `KStream` objects you're merging must be of the same type.  If you have 2 `KStream` instances with different key and/or value types, you'll have to use the `KStream.map` (or `KStream.mapValues`) to get the types to line-up before merging.
+Note when using the `merge` operator the keys and values of the two `KStream` objects you're merging must be of the same type.  If you have 2 `KStream` instances with different key and/or value types, you'll have to use the `KStream.map` (or `KStream.mapValues`) operation first to get the types to line-up before merging.


### PR DESCRIPTION
### Description

From user feedback about using `KStream.merge` and key and value types.  Note that this PR is a text-only update.

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/MINOR_userback_add_details_for_merge/merge-many-streams-into-one-stream/confluent.html

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
