### PR TITLE
DP-9632: remediate duplicate Semaphore workflows

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -8,3 +8,6 @@ github:
 semaphore:
   enable: true
   pipeline_enable: false
+  branches:
+  - master
+  - release

--- a/service.yml
+++ b/service.yml
@@ -8,7 +8,3 @@ github:
 semaphore:
   enable: true
   pipeline_enable: false
-  triggers:
-  - branches
-  - pull_requests
-  branches: []


### PR DESCRIPTION
This repo currently has a Semaphore project that triggers workflows on both pull requests (PR) and all branches. This configuration results in 2 workflow executions when a PR is created or updated. This PR changes the project configuration to use the default behavior for triggers, `[branches, tags, pull_requests]`, and to whitelist branches that match `[master, release]`.
