### PR TITLE
MINOR: fixes for tutorial showing null keys

### DIFF
--- a/_includes/tutorials/rekeying/ksql/code/Makefile
+++ b/_includes/tutorials/rekeying/ksql/code/Makefile
@@ -11,7 +11,7 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	mkdir -p $(TEST_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/rekeying/ksql.yml $(TEMP_DIR) $(SEQUENCE)
-	#bash -c "diff --strip-trailing-cr <(cut -d ',' -f 3- $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 3- $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
+	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 3- $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 3- $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
 	diff --strip-trailing-cr --ignore-space-change $(STEPS_DIR)/dev/expected-describe.log $(DEV_OUTPUTS_DIR)/describe-output/output-0.log
 	# Unless ksqlDB adds support for SLEEP, or we split the docker_ksql_cli_session and insert a bash sleep step (a lot of heavy lifting), this option will hopefully suffice for now. It simply greps out the offending KAFKA_STRING mention in the test at the end.
 	# See https://github.com/confluentinc/kafka-tutorials/issues/510

--- a/_includes/tutorials/rekeying/ksql/code/Makefile
+++ b/_includes/tutorials/rekeying/ksql/code/Makefile
@@ -11,9 +11,9 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	mkdir -p $(TEST_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/rekeying/ksql.yml $(TEMP_DIR) $(SEQUENCE)
-	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 3- $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 3- $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
+	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2-5 $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 2-5 $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
 	diff --strip-trailing-cr --ignore-space-change $(STEPS_DIR)/dev/expected-describe.log $(DEV_OUTPUTS_DIR)/describe-output/output-0.log
 	# Unless ksqlDB adds support for SLEEP, or we split the docker_ksql_cli_session and insert a bash sleep step (a lot of heavy lifting), this option will hopefully suffice for now. It simply greps out the offending KAFKA_STRING mention in the test at the end.
 	# See https://github.com/confluentinc/kafka-tutorials/issues/510
-	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 3- $(STEPS_DIR)/dev/expected-print-output.log|sort) <(cut -d ',' -f 3- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort|grep -v KAFKA_STRING)"	
+	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2-5 $(STEPS_DIR)/dev/expected-print-output.log|sort) <(cut -d ',' -f 2-5 $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort|grep -v KAFKA_STRING)"	
 	reset

--- a/_includes/tutorials/rekeying/ksql/code/Makefile
+++ b/_includes/tutorials/rekeying/ksql/code/Makefile
@@ -11,9 +11,9 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	mkdir -p $(TEST_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/rekeying/ksql.yml $(TEMP_DIR) $(SEQUENCE)
-	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
+	#bash -c "diff --strip-trailing-cr <(cut -d ',' -f 3- $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 3- $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
 	diff --strip-trailing-cr --ignore-space-change $(STEPS_DIR)/dev/expected-describe.log $(DEV_OUTPUTS_DIR)/describe-output/output-0.log
 	# Unless ksqlDB adds support for SLEEP, or we split the docker_ksql_cli_session and insert a bash sleep step (a lot of heavy lifting), this option will hopefully suffice for now. It simply greps out the offending KAFKA_STRING mention in the test at the end.
 	# See https://github.com/confluentinc/kafka-tutorials/issues/510
-	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-output.log|sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort|grep -v KAFKA_STRING)"	
+	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 3- $(STEPS_DIR)/dev/expected-print-output.log|sort) <(cut -d ',' -f 3- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort|grep -v KAFKA_STRING)"	
 	reset

--- a/_includes/tutorials/rekeying/ksql/code/src/statements.sql
+++ b/_includes/tutorials/rekeying/ksql/code/src/statements.sql
@@ -1,4 +1,4 @@
-CREATE STREAM ratings (old INT KEY, id INT, rating DOUBLE)
+CREATE STREAM ratings (old INT, id INT, rating DOUBLE)
     WITH (kafka_topic='ratings', 
           partitions=2,
           value_format='avro');

--- a/_includes/tutorials/rekeying/ksql/code/test/input.json
+++ b/_includes/tutorials/rekeying/ksql/code/test/input.json
@@ -2,72 +2,72 @@
   "inputs": [
     {
       "topic": "ratings",
-      "key": 1,
       "value": {
+        "old": 1,
         "id": 294,
         "rating": 8.2
       }
     },
     {
       "topic": "ratings",
-      "key": 2,
       "value": {
+        "old": 2,
         "id": 294,
         "rating": 8.5
       }
     },
     {
       "topic": "ratings",
-      "key": 3,
       "value": {
+        "old": 3,
         "id": 354,
         "rating": 9.9
       }
     },
     {
       "topic": "ratings",
-      "key": 4,
       "value": {
+        "old": 4,
         "id": 354,
         "rating": 9.7
       }
     },
     {
       "topic": "ratings",
-      "key": 5,
       "value": {
+        "old": 5,
         "id": 782,
         "rating": 7.8
       }
     },
     {
       "topic": "ratings",
-      "key": 6,
       "value": {
+        "old": 6,
         "id": 782,
         "rating": 7.7
       }
     },
     {
       "topic": "ratings",
-      "key": 7,
       "value": {
+        "old": 7,
         "id": 128,
         "rating": 8.7
       }
     },
     {
       "topic": "ratings",
-      "key": 8,
       "value": {
+        "old": 8,
         "id": 128,
         "rating": 8.4
       }
     },
     {
       "topic": "ratings",
-      "key": 9,
       "value": {
+        "old": 9,
         "id": 780,
         "rating": 2.1
       }

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/create-ratings-stream.sql
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/create-ratings-stream.sql
@@ -1,4 +1,4 @@
-CREATE STREAM ratings (old INT KEY, id INT, rating DOUBLE)
+CREATE STREAM ratings (old INT, id INT, rating DOUBLE)
     WITH (kafka_topic='ratings', 
           partitions=2, 
           value_format='avro');

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-describe.log
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-describe.log
@@ -2,7 +2,7 @@ Name                 : RATINGS_REKEYED
  Field  | Type
 
  ID     | INTEGER          (key)
- RATING | DOUBLE
  OLD    | INTEGER
+ RATING | DOUBLE
 
 For runtime statistics and query details run: DESCRIBE <Stream,Table> EXTENDED;

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-input.log
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-input.log
@@ -1,12 +1,12 @@
-Key format: KAFKA_INT or KAFKA_STRING
+Key format: ¯\_(ツ)_/¯ - no data processed
 Value format: AVRO
-rowtime: 2020/05/04 23:24:30.376 Z, key: 1, value: {"ID": 294, "RATING": 8.2}, partition: 0
-rowtime: 2020/05/04 23:24:30.684 Z, key: 2, value: {"ID": 294, "RATING": 8.5}, partition: 1
-rowtime: 2020/05/04 23:24:30.781 Z, key: 3, value: {"ID": 354, "RATING": 9.9}, partition: 1
-rowtime: 2020/05/04 23:24:30.949 Z, key: 4, value: {"ID": 354, "RATING": 9.7}, partition: 1
-rowtime: 2020/05/04 23:24:31.099 Z, key: 5, value: {"ID": 782, "RATING": 7.8}, partition: 0
-rowtime: 2020/05/04 23:24:30.560 Z, key: 6, value: {"ID": 782, "RATING": 7.7}, partition: 1
-rowtime: 2020/05/04 23:24:30.873 Z, key: 7, value: {"ID": 128, "RATING": 8.7}, partition: 1
-rowtime: 2020/05/04 23:24:31.021 Z, key: 8, value: {"ID": 128, "RATING": 8.4}, partition: 0
-rowtime: 2020/05/04 23:24:31.178 Z, key: 9, value: {"ID": 780, "RATING": 2.1}, partition: 0
+rowtime: 2022/12/02 21:56:48.720 Z, key: <null>, value: {"OLD": 2, "ID": 294, "RATING": 8.5}, partition: 1
+rowtime: 2022/12/02 21:56:48.829 Z, key: <null>, value: {"OLD": 5, "ID": 782, "RATING": 7.8}, partition: 1
+rowtime: 2022/12/02 21:56:48.875 Z, key: <null>, value: {"OLD": 6, "ID": 782, "RATING": 7.7}, partition: 1
+rowtime: 2022/12/02 21:56:48.946 Z, key: <null>, value: {"OLD": 8, "ID": 128, "RATING": 8.4}, partition: 1
+rowtime: 2022/12/02 21:56:48.652 Z, key: <null>, value: {"OLD": 1, "ID": 294, "RATING": 8.2}, partition: 0
+rowtime: 2022/12/02 21:56:48.757 Z, key: <null>, value: {"OLD": 3, "ID": 354, "RATING": 9.9}, partition: 0
+rowtime: 2022/12/02 21:56:48.793 Z, key: <null>, value: {"OLD": 4, "ID": 354, "RATING": 9.7}, partition: 0
+rowtime: 2022/12/02 21:56:48.910 Z, key: <null>, value: {"OLD": 7, "ID": 128, "RATING": 8.7}, partition: 0
+rowtime: 2022/12/02 21:56:48.982 Z, key: <null>, value: {"OLD": 9, "ID": 780, "RATING": 2.1}, partition: 0
 Topic printing ceased

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-input.log
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-input.log
@@ -1,12 +1,12 @@
 Key format: ¯\_(ツ)_/¯ - no data processed
 Value format: AVRO
-rowtime: 2022/12/02 21:56:48.720 Z, key: <null>, value: {"OLD": 2, "ID": 294, "RATING": 8.5}, partition: 1
+rowtime: 2022/12/02 21:56:48.720 Z, key: <null>, value: {"OLD": 2, "ID": 294, "RATING": 8.5}, partition: 0
 rowtime: 2022/12/02 21:56:48.829 Z, key: <null>, value: {"OLD": 5, "ID": 782, "RATING": 7.8}, partition: 1
 rowtime: 2022/12/02 21:56:48.875 Z, key: <null>, value: {"OLD": 6, "ID": 782, "RATING": 7.7}, partition: 1
 rowtime: 2022/12/02 21:56:48.946 Z, key: <null>, value: {"OLD": 8, "ID": 128, "RATING": 8.4}, partition: 1
-rowtime: 2022/12/02 21:56:48.652 Z, key: <null>, value: {"OLD": 1, "ID": 294, "RATING": 8.2}, partition: 0
-rowtime: 2022/12/02 21:56:48.757 Z, key: <null>, value: {"OLD": 3, "ID": 354, "RATING": 9.9}, partition: 0
-rowtime: 2022/12/02 21:56:48.793 Z, key: <null>, value: {"OLD": 4, "ID": 354, "RATING": 9.7}, partition: 0
-rowtime: 2022/12/02 21:56:48.910 Z, key: <null>, value: {"OLD": 7, "ID": 128, "RATING": 8.7}, partition: 0
-rowtime: 2022/12/02 21:56:48.982 Z, key: <null>, value: {"OLD": 9, "ID": 780, "RATING": 2.1}, partition: 0
+rowtime: 2022/12/02 21:56:48.652 Z, key: <null>, value: {"OLD": 1, "ID": 294, "RATING": 8.2}, partition: 1
+rowtime: 2022/12/02 21:56:48.757 Z, key: <null>, value: {"OLD": 3, "ID": 354, "RATING": 9.9}, partition: 1
+rowtime: 2022/12/02 21:56:48.793 Z, key: <null>, value: {"OLD": 4, "ID": 354, "RATING": 9.7}, partition: 1
+rowtime: 2022/12/02 21:56:48.910 Z, key: <null>, value: {"OLD": 7, "ID": 128, "RATING": 8.7}, partition: 1
+rowtime: 2022/12/02 21:56:48.982 Z, key: <null>, value: {"OLD": 9, "ID": 780, "RATING": 2.1}, partition: 1
 Topic printing ceased

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-output.log
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-output.log
@@ -1,12 +1,12 @@
 Key format: KAFKA_INT
 Value format: AVRO
-rowtime: 2020/05/04 23:24:30.376 Z, key: 128, value: {"RATING": 8.4, "OLD": 8}, partition: 0
-rowtime: 2020/05/04 23:24:30.684 Z, key: 128, value: {"RATING": 8.7, "OLD": 7}, partition: 0
-rowtime: 2020/05/04 23:24:30.781 Z, key: 294, value: {"RATING": 8.2, "OLD": 1}, partition: 0
-rowtime: 2020/05/04 23:24:30.949 Z, key: 294, value: {"RATING": 8.5, "OLD": 2}, partition: 0
-rowtime: 2020/05/04 23:24:31.099 Z, key: 354, value: {"RATING": 9.7, "OLD": 4}, partition: 0
-rowtime: 2020/05/04 23:24:30.560 Z, key: 354, value: {"RATING": 9.9, "OLD": 3}, partition: 0
-rowtime: 2020/05/04 23:24:30.873 Z, key: 780, value: {"RATING": 2.1, "OLD": 9}, partition: 1
-rowtime: 2020/05/04 23:24:31.021 Z, key: 782, value: {"RATING": 7.7, "OLD": 6}, partition: 0
-rowtime: 2020/05/04 23:24:31.178 Z, key: 782, value: {"RATING": 7.8, "OLD": 5}, partition: 0
+rowtime: 2020/05/04 23:24:30.376 Z, key: 128, value: {"OLD": 8, "RATING": 8.4}, partition: 0
+rowtime: 2020/05/04 23:24:30.684 Z, key: 128, value: {"OLD": 7, "RATING": 8.7}, partition: 0
+rowtime: 2020/05/04 23:24:30.781 Z, key: 294, value: {"OLD": 1, "RATING": 8.2}, partition: 0
+rowtime: 2020/05/04 23:24:30.949 Z, key: 294, value: {"OLD": 2, "RATING": 8.5}, partition: 0
+rowtime: 2020/05/04 23:24:31.099 Z, key: 354, value: {"OLD": 4, "RATING": 9.7}, partition: 0
+rowtime: 2020/05/04 23:24:30.560 Z, key: 354, value: {"OLD": 3, "RATING": 9.9}, partition: 0
+rowtime: 2020/05/04 23:24:30.873 Z, key: 780, value: {"OLD": 9, "RATING": 2.1}, partition: 1
+rowtime: 2020/05/04 23:24:31.021 Z, key: 782, value: {"OLD": 6, "RATING": 7.7}, partition: 0
+rowtime: 2020/05/04 23:24:31.178 Z, key: 782, value: {"OLD": 5, "RATING": 7.8}, partition: 0
 Topic printing ceased


### PR DESCRIPTION
### Description

[asana](https://app.asana.com/0/1201906632362444/1203482242668693/f)

This tutorial was written to demonstrate converting a keyless stream to one with keys.  However, in the original tutorial, the initial stream contains keys, so it's been updated to reflect the narrative of the tutorial.
### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
