### PR TITLE
MINOR: Parallelize the KT build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -98,7 +98,7 @@ blocks:
             - cache store site-$SEMAPHORE_GIT_SHA _site
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
-    dependencies: []
+    dependencies: ["Build the website"]
     task:
       prologue:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -112,6 +112,7 @@ blocks:
             - ./gradlew clean test
 
   - name: Run first block of tests (mostly Kafka and KStreams)
+    dependencies: ["Tests"]
     execution_time_limit:
       minutes: 20
     task:
@@ -285,6 +286,7 @@ blocks:
             - make -C _includes/tutorials/confluent-parallel-consumer-application/kafka/code tutorial
 
   - name: Run second block of tests (ksqlDB recipes)
+    dependencies: ["Tests"]
     execution_time_limit:
       minutes: 20
     task:
@@ -409,6 +411,7 @@ blocks:
             - make -C _includes/tutorials/omnichannel-commerce/ksql-test/code tutorial
 
   - name: Run third block of tests (mostly ksqlDB)
+    dependencies: ["Tests"]
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -114,7 +114,7 @@ blocks:
             - ./gradlew clean test
 
   - name: Run first block of tests (mostly Kafka and KStreams)
-    dependencies: ["Tests"]
+    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     execution_time_limit:
       minutes: 20
     task:
@@ -288,7 +288,7 @@ blocks:
             - make -C _includes/tutorials/confluent-parallel-consumer-application/kafka/code tutorial
 
   - name: Run second block of tests (ksqlDB recipes)
-    dependencies: ["Tests"]
+    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     execution_time_limit:
       minutes: 20
     task:
@@ -413,7 +413,7 @@ blocks:
             - make -C _includes/tutorials/omnichannel-commerce/ksql-test/code tutorial
 
   - name: Run third block of tests (mostly ksqlDB)
-    dependencies: ["Tests"]
+    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,6 +80,7 @@ promotions:
 
 blocks:
   - name: Build the website
+    dependencies: []
     task:
       prologue:
         commands:
@@ -97,6 +98,7 @@ blocks:
             - cache store site-$SEMAPHORE_GIT_SHA _site
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
+    dependencies: []
     task:
       prologue:
         commands:


### PR DESCRIPTION
### Description

This PR parallelizes the testing blocks.  This will make merging ksqlDB PRs much easier since all three blocks will execute; we won't have to re-run the build and cross our fingers it will make it to the third block.  Also, it should cut down on the build time, which is a good thing.


### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
