### PR TITLE
KT release [December 6, 2022]

### DIFF
--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,37 @@
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: kafka-tutorials
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/kafka-tutorials.git
+    run_on:
+    - branches
+    - tags
+    - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+    whitelist:
+      branches:
+      - master
+      - release
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,6 +80,7 @@ promotions:
 
 blocks:
   - name: Build the website
+    dependencies: []
     task:
       prologue:
         commands:
@@ -97,6 +98,7 @@ blocks:
             - cache store site-$SEMAPHORE_GIT_SHA _site
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
+    dependencies: ["Build the website"]
     task:
       prologue:
         commands:
@@ -112,6 +114,7 @@ blocks:
             - ./gradlew clean test
 
   - name: Run first block of tests (mostly Kafka and KStreams)
+    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     execution_time_limit:
       minutes: 20
     task:
@@ -285,6 +288,7 @@ blocks:
             - make -C _includes/tutorials/confluent-parallel-consumer-application/kafka/code tutorial
 
   - name: Run second block of tests (ksqlDB recipes)
+    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     execution_time_limit:
       minutes: 20
     task:
@@ -409,6 +413,7 @@ blocks:
             - make -C _includes/tutorials/omnichannel-commerce/ksql-test/code tutorial
 
   - name: Run third block of tests (mostly ksqlDB)
+    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,27 +23,27 @@ global_job_config:
       - cache restore gradle-7.5.1
       - sudo update-alternatives --install /usr/bin/gradle gradle ~/.gradle/gradle-7.5.1/bin/gradle 10
       - |
-        if ! cache has_key cp-7.1.0-images; then
-          docker pull confluentinc/cp-kafka:7.1.0
-          docker pull confluentinc/cp-zookeeper:7.1.0
-          docker pull confluentinc/cp-schema-registry:7.1.0
-          docker pull confluentinc/cp-kafka-connect-base:7.1.0
-          docker pull confluentinc/cp-server-connect-base:7.1.0
-          docker pull confluentinc/ksqldb-server:0.24.0
-          docker pull confluentinc/ksqldb-cli:0.24.0
-          docker save confluentinc/cp-kafka:7.1.0 \
-                      confluentinc/cp-zookeeper:7.1.0 \
-                      confluentinc/cp-schema-registry:7.1.0 \
-                      confluentinc/cp-kafka-connect-base:7.1.0 \
-                      confluentinc/cp-server-connect-base:7.1.0 \
-                      confluentinc/ksqldb-server:0.24.0 \
-                      confluentinc/ksqldb-cli:0.24.0 \
+        if ! cache has_key cp-7.3.0-images; then
+          docker pull confluentinc/cp-kafka:7.3.0
+          docker pull confluentinc/cp-zookeeper:7.3.0
+          docker pull confluentinc/cp-schema-registry:7.3.0
+          docker pull confluentinc/cp-kafka-connect-base:7.3.0
+          docker pull confluentinc/cp-server-connect-base:7.3.0
+          docker pull confluentinc/ksqldb-server:0.28.2
+          docker pull confluentinc/ksqldb-cli:0.28.2
+          docker save confluentinc/cp-kafka:7.3.0 \
+                      confluentinc/cp-zookeeper:7.3.0 \
+                      confluentinc/cp-schema-registry:7.3.0 \
+                      confluentinc/cp-kafka-connect-base:7.3.0 \
+                      confluentinc/cp-server-connect-base:7.3.0 \
+                      confluentinc/ksqldb-server:0.28.2 \
+                      confluentinc/ksqldb-cli:0.28.2 \
                       | gzip > cp.tar.gz
-          cache store cp-7.1.0-images cp.tar.gz
+          cache store cp-7.3.0-images cp.tar.gz
           rm -f cp.tar.gz
         else
-          docker image inspect confluentinc/cp-kafka:7.1.0 || \
-            (cache restore cp-7.1.0-images && docker load < cp.tar.gz && rm -f cp.tar.gz)
+          docker image inspect confluentinc/cp-kafka:7.3.0 || \
+            (cache restore cp-7.3.0-images && docker load < cp.tar.gz && rm -f cp.tar.gz)
         fi
       - make install-vault
       - . vault-bin/vault-setup

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ TUTORIAL_SHORT_NAME=my-tutorial-name
 # the MAIN_CLASS variable will generate a test named MAIN_CLASSTest
 MAIN_CLASS=FilteringCode
 AK_VERSION=3.1.0
-CP_VERSION=7.1.0
-KSQLDB_VERSION=0.24.0
+CP_VERSION=7.3.0
+KSQLDB_VERSION=0.28.2
 SEMAPHORE_TEST_NAME="Test name for Semaphore run"
 PERMALINK="seo-friendly-link-to-my-tutorial"
 ```

--- a/_data/harnesses/aggregating-average/kstreams.yml
+++ b/_data/harnesses/aggregating-average/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/aggregating-count/ksql.yml
+++ b/_data/harnesses/aggregating-count/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/aggregating-count/kstreams.yml
+++ b/_data/harnesses/aggregating-count/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/aggregating-minmax/ksql.yml
+++ b/_data/harnesses/aggregating-minmax/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/aggregating-minmax/kstreams.yml
+++ b/_data/harnesses/aggregating-minmax/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/aggregating-sum/ksql.yml
+++ b/_data/harnesses/aggregating-sum/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/aggregating-sum/kstreams.yml
+++ b/_data/harnesses/aggregating-sum/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/anomaly-detection/ksql.yml
+++ b/_data/harnesses/anomaly-detection/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/change-topic-partitions-replicas/ksql.yml
+++ b/_data/harnesses/change-topic-partitions-replicas/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/cogrouping-streams/kstreams.yml
+++ b/_data/harnesses/cogrouping-streams/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/column-difference/ksql.yml
+++ b/_data/harnesses/column-difference/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/concatenation/ksql.yml
+++ b/_data/harnesses/concatenation/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/confluent-parallel-consumer-application/kafka.yml
+++ b/_data/harnesses/confluent-parallel-consumer-application/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/connect-add-key-to-source/kafka.yml
+++ b/_data/harnesses/connect-add-key-to-source/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/connect-add-key-to-source/ksql.yml
+++ b/_data/harnesses/connect-add-key-to-source/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/connect-add-key-to-source/kstreams.yml
+++ b/_data/harnesses/connect-add-key-to-source/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/connect-sink-timestamp/ksql.yml
+++ b/_data/harnesses/connect-sink-timestamp/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/console-consumer-primitive-keys-values/kafka.yml
+++ b/_data/harnesses/console-consumer-primitive-keys-values/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/console-consumer-producer-avro/kafka.yml
+++ b/_data/harnesses/console-consumer-producer-avro/kafka.yml
@@ -13,6 +13,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/console-consumer-producer-basic/kafka.yml
+++ b/_data/harnesses/console-consumer-producer-basic/kafka.yml
@@ -13,6 +13,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/console-consumer-read-specific-offsets-partition/kafka.yml
+++ b/_data/harnesses/console-consumer-read-specific-offsets-partition/kafka.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/count-messages/kafka.yml
+++ b/_data/harnesses/count-messages/kafka.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/count-messages/ksql.yml
+++ b/_data/harnesses/count-messages/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/creating-first-apache-kafka-streams-application/kstreams.yml
+++ b/_data/harnesses/creating-first-apache-kafka-streams-application/kstreams.yml
@@ -8,6 +8,11 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
 
     - title: Initialize the project
       content:

--- a/_data/harnesses/deserialization-errors/ksql.yml
+++ b/_data/harnesses/deserialization-errors/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/dynamic-output-topic/kstreams.yml
+++ b/_data/harnesses/dynamic-output-topic/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/error-handling/kstreams.yml
+++ b/_data/harnesses/error-handling/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/filtering/ksql.yml
+++ b/_data/harnesses/filtering/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/filtering/kstreams.yml
+++ b/_data/harnesses/filtering/kstreams.yml
@@ -7,6 +7,12 @@ answer:
             file: tutorials/filtering/kstreams/markup/answer/short-answer.adoc
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/finding-distinct/ksql.yml
+++ b/_data/harnesses/finding-distinct/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/finding-distinct/kstreams.yml
+++ b/_data/harnesses/finding-distinct/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/fk-joins/kstreams.yml
+++ b/_data/harnesses/fk-joins/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/flatten-nested-data/ksql.yml
+++ b/_data/harnesses/flatten-nested-data/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/generate-test-data-streams/kafka.yml
+++ b/_data/harnesses/generate-test-data-streams/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/generate-test-data-streams/ksql.yml
+++ b/_data/harnesses/generate-test-data-streams/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/geo-distance/ksql.yml
+++ b/_data/harnesses/geo-distance/ksql.yml
@@ -7,6 +7,12 @@ answer:
             file: tutorials/geo-distance/ksql/markup/answer/geo-distance.adoc
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/hopping-windows/ksql.yml
+++ b/_data/harnesses/hopping-windows/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/joining-stream-stream/ksql.yml
+++ b/_data/harnesses/joining-stream-stream/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/joining-stream-table/ksql.yml
+++ b/_data/harnesses/joining-stream-table/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/joining-stream-table/kstreams.yml
+++ b/_data/harnesses/joining-stream-table/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/joining-table-table/ksql.yml
+++ b/_data/harnesses/joining-table-table/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/kafka-connect-datagen/kafka.yml
+++ b/_data/harnesses/kafka-connect-datagen/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/kafka-consumer-application/kafka.yml
+++ b/_data/harnesses/kafka-consumer-application/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/kafka-producer-application-callback/kafka.yml
+++ b/_data/harnesses/kafka-producer-application-callback/kafka.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/kafka-producer-application/kafka.yml
+++ b/_data/harnesses/kafka-producer-application/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/kafka-streams-schedule-operations/kstreams.yml
+++ b/_data/harnesses/kafka-streams-schedule-operations/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/ksql-heterogeneous-json/ksql.yml
+++ b/_data/harnesses/ksql-heterogeneous-json/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/ksql-nested-json/ksql.yml
+++ b/_data/harnesses/ksql-nested-json/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/masking-data/ksql.yml
+++ b/_data/harnesses/masking-data/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/merging/ksql.yml
+++ b/_data/harnesses/merging/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/merging/kstreams.yml
+++ b/_data/harnesses/merging/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/message-ordering/kafka.yml
+++ b/_data/harnesses/message-ordering/kafka.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/multi-joins/ksql.yml
+++ b/_data/harnesses/multi-joins/ksql.yml
@@ -7,6 +7,12 @@ answer:
             file: tutorials/multi-joins/ksql/markup/answer/multi-way-join.adoc
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/multiple-event-types/kafka.yml
+++ b/_data/harnesses/multiple-event-types/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/naming-changelog-repartition-topics/kstreams.yml
+++ b/_data/harnesses/naming-changelog-repartition-topics/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/produce-consume-lang/scala.yml
+++ b/_data/harnesses/produce-consume-lang/scala.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Get Confluent Platform
       content:
         - action: execute

--- a/_data/harnesses/rekeying-function/ksql.yml
+++ b/_data/harnesses/rekeying-function/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
 

--- a/_data/harnesses/rekeying/ksql.yml
+++ b/_data/harnesses/rekeying/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/schedule-ktable-ttl-aggregate/kstreams.yml
+++ b/_data/harnesses/schedule-ktable-ttl-aggregate/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/schedule-ktable-ttl/kstreams.yml
+++ b/_data/harnesses/schedule-ktable-ttl/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/serialization/ksql.yml
+++ b/_data/harnesses/serialization/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/serialization/kstreams.yml
+++ b/_data/harnesses/serialization/kstreams.yml
@@ -1,6 +1,12 @@
 # =========== DEV Harness ===========
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/session-windows/ksql.yml
+++ b/_data/harnesses/session-windows/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/session-windows/kstreams.yml
+++ b/_data/harnesses/session-windows/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/sliding-windows/kstreams.yml
+++ b/_data/harnesses/sliding-windows/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/splitting/ksql.yml
+++ b/_data/harnesses/splitting/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/splitting/kstreams.yml
+++ b/_data/harnesses/splitting/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/streams-to-table/kstreams.yml
+++ b/_data/harnesses/streams-to-table/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/time-concepts/ksql.yml
+++ b/_data/harnesses/time-concepts/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/transforming/kafka.yml
+++ b/_data/harnesses/transforming/kafka.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/transforming/ksql.yml
+++ b/_data/harnesses/transforming/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/transforming/kstreams.yml
+++ b/_data/harnesses/transforming/kstreams.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/tumbling-windows/ksql.yml
+++ b/_data/harnesses/tumbling-windows/ksql.yml
@@ -8,6 +8,12 @@ answer:
 
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/tumbling-windows/kstreams.yml
+++ b/_data/harnesses/tumbling-windows/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/udf/ksql.yml
+++ b/_data/harnesses/udf/ksql.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/_data/harnesses/window-final-result/kstreams.yml
+++ b/_data/harnesses/window-final-result/kstreams.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Get Confluent Platform
       content:
         - action: execute

--- a/_includes/shared/markup/dev/docker-prerequisite.adoc
+++ b/_includes/shared/markup/dev/docker-prerequisite.adoc
@@ -1,0 +1,6 @@
+This tutorial installs Confluent Platform using Docker. Before proceeding:
+
+* &#x2022; Install https://docs.docker.com/desktop/[Docker Desktop] (version `4.0.0` or later) or https://docs.docker.com/engine/install/[Docker Engine] (version `19.03.0` or later) if you don't already have it
+* &#x2022; Install the https://docs.docker.com/compose/install/[Docker Compose plugin] if you don't already have it. This isn't necessary if you have Docker Desktop since it includes Docker Compose.
+* &#x2022; Start Docker if it's not already running, either by starting Docker Desktop or, if you manage Docker Engine with `systemd`, https://docs.docker.com/config/daemon/systemd/[via systemctl]
+* &#x2022; Verify that Docker is set up properly by ensuring no errors are output when you run `docker info` and `docker compose version` on the command line

--- a/_includes/tutorials/SSH-attack/confluent/code/tutorial-steps/dev/Dockerfile
+++ b/_includes/tutorials/SSH-attack/confluent/code/tutorial-steps/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-server-connect-base:7.1.0
+FROM confluentinc/cp-server-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/SSH-attack/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/SSH-attack/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
@@ -30,7 +30,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
-  implementation "org.slf4j:slf4j-simple:2.0.3"
+  implementation "org.slf4j:slf4j-simple:2.0.5"
   implementation "org.apache.kafka:kafka-streams:3.3.1"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation "com.typesafe:config:1.4.2"

--- a/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.3"
-  implementation "org.apache.kafka:kafka-streams:3.1.0"
-  implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
+  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation "com.typesafe:config:1.4.2"
 
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
   testImplementation "junit:junit:4.13.2"
   testImplementation 'org.hamcrest:hamcrest:2.2'
 

--- a/_includes/tutorials/aggregating-average/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/aggregating-average/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -15,7 +15,7 @@ services:
       - cp
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -34,7 +34,7 @@ services:
       - cp
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/aggregating-count/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/aggregating-count/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
@@ -30,7 +30,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
@@ -31,9 +31,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/aggregating-count/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/aggregating-count/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/aggregating-minmax/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/aggregating-minmax/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
@@ -32,7 +32,7 @@ mainClassName = "io.confluent.developer.AggregatingMinMax"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
@@ -33,9 +33,9 @@ mainClassName = "io.confluent.developer.AggregatingMinMax"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/aggregating-sum/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/aggregating-sum/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/aggregating-sum/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/anomaly-detection/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/anomaly-detection/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -32,7 +32,7 @@ services:
       KAFKA_LOG_RETENTION_MS: -1
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -44,7 +44,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -63,7 +63,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/audit-logs/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/audit-logs/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/aviation/confluent/code/tutorial-steps/dev/docker-compose.yml
+++ b/_includes/tutorials/aviation/confluent/code/tutorial-steps/dev/docker-compose.yml
@@ -2,14 +2,14 @@
 version: '3'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     container_name: zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     container_name: broker
     depends_on:
       - zookeeper
@@ -28,7 +28,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 100
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     ports:
       - 8081:8081
     container_name: schema-registry
@@ -44,7 +44,7 @@ services:
     # To connect to the DB: 
     #   docker exec -it ksqldb bash -c 'ksql http://localhost:8088'
     # *-----------------------------*  
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     container_name: ksqldb
     depends_on:
       - broker

--- a/_includes/tutorials/aviation/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/aviation/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/campaign-finance/ksql-test/code/Dockerfile
+++ b/_includes/tutorials/campaign-finance/ksql-test/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:7.1.0
+FROM confluentinc/cp-kafka-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/campaign-finance/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/campaign-finance/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -32,7 +32,7 @@ services:
       KAFKA_LOG_RETENTION_MS: -1
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -51,7 +51,7 @@ services:
       KSQL_KSQL_CONNECT_URL: "http://connect:8083"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/change-topic-partitions-replicas/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/change-topic-partitions-replicas/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   broker2:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker2
     container_name: broker2
     depends_on:
@@ -49,7 +49,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -61,7 +61,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -79,7 +79,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/clickstream/ksql-test/code/Dockerfile
+++ b/_includes/tutorials/clickstream/ksql-test/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:7.1.0
+FROM confluentinc/cp-kafka-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/clickstream/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/clickstream/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -50,7 +50,7 @@ services:
       KSQL_KSQL_CONNECT_URL: "http://connect:8083"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
@@ -32,10 +32,10 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
 
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
@@ -31,7 +31,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
 

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/column-difference/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/column-difference/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -62,7 +62,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/concatenation/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/concatenation/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -62,7 +62,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/confluent-parallel-consumer-application/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/connect-add-key-to-source/kafka/code/Dockerfile-connect
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/code/Dockerfile-connect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:7.1.0
+FROM confluentinc/cp-kafka-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/connect-add-key-to-source/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/connect-add-key-to-source/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/connect-add-key-to-source/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/connect-add-key-to-source/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb
     container_name: ksqldb
     depends_on:
@@ -91,7 +91,7 @@ services:
         sleep infinity
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/Dockerfile-connect
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/Dockerfile-connect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:7.1.0
+FROM confluentinc/cp-kafka-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.3"
-  implementation "org.apache.kafka:kafka-streams:3.1.0"
-  implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
+  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation 'com.google.code.gson:gson:2.10'
 
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
@@ -30,7 +30,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
-  implementation "org.slf4j:slf4j-simple:2.0.3"
+  implementation "org.slf4j:slf4j-simple:2.0.5"
   implementation "org.apache.kafka:kafka-streams:3.3.1"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation 'com.google.code.gson:gson:2.10'

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/connect-sink-timestamp/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/connect-sink-timestamp/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -92,7 +92,7 @@ services:
         sleep infinity
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/console-consumer-primitive-keys-values/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -42,7 +42,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
    
   ksqldb-server:
-    image: confluentinc/cp-ksqldb-server:7.1.0
+    image: confluentinc/cp-ksqldb-server:7.3.0
     hostname: ksqldb
     container_name: ksqldb
     depends_on:

--- a/_includes/tutorials/console-consumer-producer-avro/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/console-consumer-producer-avro/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/console-consumer-producer-basic/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/console-consumer-producer-basic/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/confluent/code/tutorial-steps/dev/console-consumer-keys-partition-offset.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/confluent/code/tutorial-steps/dev/console-consumer-keys-partition-offset.sh
@@ -1,4 +1,4 @@
-docker run -v $PWD/configuration/ccloud.properties:/tmp/ccloud.properties confluentinc/cp-kafka:7.1.0 \
+docker run -v $PWD/configuration/ccloud.properties:/tmp/ccloud.properties confluentinc/cp-kafka:7.3.0 \
   bash -c 'kafka-console-consumer \
     --topic example-topic \
     --bootstrap-server `grep "^\s*bootstrap.server" /tmp/ccloud.properties | tail -1` \

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/confluent/code/tutorial-steps/dev/console-consumer-keys-partition-one.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/confluent/code/tutorial-steps/dev/console-consumer-keys-partition-one.sh
@@ -1,4 +1,4 @@
-docker run -v $PWD/configuration/ccloud.properties:/tmp/ccloud.properties confluentinc/cp-kafka:7.1.0 \
+docker run -v $PWD/configuration/ccloud.properties:/tmp/ccloud.properties confluentinc/cp-kafka:7.3.0 \
   bash -c 'kafka-console-consumer \
     --topic example-topic \
     --bootstrap-server `grep "^\s*bootstrap.server" /tmp/ccloud.properties | tail -1` \

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/confluent/code/tutorial-steps/dev/console-consumer-keys-partition-zero.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/confluent/code/tutorial-steps/dev/console-consumer-keys-partition-zero.sh
@@ -1,4 +1,4 @@
-docker run -v $PWD/configuration/ccloud.properties:/tmp/ccloud.properties confluentinc/cp-kafka:7.1.0 \
+docker run -v $PWD/configuration/ccloud.properties:/tmp/ccloud.properties confluentinc/cp-kafka:7.3.0 \
   bash -c 'kafka-console-consumer \
     --topic example-topic \
     --bootstrap-server `grep "^\s*bootstrap.server" /tmp/ccloud.properties | tail -1` \

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/count-messages/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/count-messages/kafka/code/docker-compose.yml
@@ -2,14 +2,14 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     container_name: zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     container_name: broker
     depends_on:
       - zookeeper
@@ -49,7 +49,7 @@ services:
     # To connect to ksqlDB CLI
     #   docker exec --interactive --tty ksqldb ksql http://localhost:8088
     # *-----------------------------*
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     container_name: ksqldb
     depends_on:
       - broker

--- a/_includes/tutorials/count-messages/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/count-messages/ksql/code/docker-compose.yml
@@ -2,14 +2,14 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     container_name: zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     container_name: broker
     depends_on:
       - zookeeper
@@ -49,7 +49,7 @@ services:
     # To connect to ksqlDB CLI
     #   docker exec --interactive --tty ksqldb ksql http://localhost:8088
     # *-----------------------------*
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     container_name: ksqldb
     depends_on:
       - broker

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
@@ -34,7 +34,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation 'com.github.javafaker:javafaker:1.0.2'
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
@@ -35,9 +35,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation 'com.github.javafaker:javafaker:1.0.2'
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/credit-card-activity/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/credit-card-activity/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/customer-journey/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/customer-journey/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/datacenter/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/datacenter/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/ddos/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/ddos/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/denormalization/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/denormalization/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/deserialization-errors/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/deserialization-errors/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@
   
   services:
     zookeeper:
-      image: confluentinc/cp-zookeeper:7.1.0
+      image: confluentinc/cp-zookeeper:7.3.0
       hostname: zookeeper
       container_name: zookeeper
       ports:
@@ -13,7 +13,7 @@
         ZOOKEEPER_TICK_TIME: 2000
   
     broker:
-      image: confluentinc/cp-kafka:7.1.0
+      image: confluentinc/cp-kafka:7.3.0
       hostname: broker
       container_name: broker
       depends_on:
@@ -31,7 +31,7 @@
         KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
     
     schema-registry:
-      image: confluentinc/cp-schema-registry:7.1.0
+      image: confluentinc/cp-schema-registry:7.3.0
       hostname: schema-registry
       container_name: schema-registry
       depends_on:
@@ -43,7 +43,7 @@
         SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
   
     ksqldb-server:
-      image: confluentinc/ksqldb-server:0.24.0
+      image: confluentinc/ksqldb-server:0.28.2
       hostname: ksqldb-server
       container_name: ksqldb-server
       depends_on:
@@ -67,7 +67,7 @@
         - ./log4j:/opt/app/log4j
   
     ksqldb-cli:
-      image: confluentinc/ksqldb-cli:0.24.0
+      image: confluentinc/ksqldb-cli:0.28.2
       container_name: ksqldb-cli
       depends_on:
         - broker

--- a/_includes/tutorials/discount-promo/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/discount-promo/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
@@ -32,9 +32,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
@@ -31,7 +31,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/dynamic-pricing/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/dynamic-pricing/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -31,7 +31,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     

--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -32,10 +32,10 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/error-handling/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/error-handling/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/filtering/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/filtering/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/filtering/kstreams/code/build.gradle
+++ b/_includes/tutorials/filtering/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
-  implementation "org.slf4j:slf4j-simple:2.0.3"
+  implementation "org.slf4j:slf4j-simple:2.0.5"
   implementation "org.apache.kafka:kafka-streams:3.3.1"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/filtering/kstreams/code/build.gradle
+++ b/_includes/tutorials/filtering/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.3"
-  implementation "org.apache.kafka:kafka-streams:3.1.0"
-  implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
   testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/filtering/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/filtering/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/finding-distinct/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/finding-distinct/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -32,7 +32,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -44,7 +44,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksql-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksql-server
     container_name: ksql-server
     depends_on:
@@ -63,7 +63,7 @@ services:
       KSQL_KSQL_STREAMS_CACHE_MAX_BYTES_BUFFERING: 0
 
   ksql-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksql-cli
     depends_on:
       - broker

--- a/_includes/tutorials/finding-distinct/kstreams/code/build.gradle
+++ b/_includes/tutorials/finding-distinct/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
-  implementation "org.slf4j:slf4j-simple:2.0.3"
+  implementation "org.slf4j:slf4j-simple:2.0.5"
   implementation "org.apache.kafka:kafka-streams:3.1.0"
   implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"

--- a/_includes/tutorials/finding-distinct/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/finding-distinct/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/firewall-splunk/confluent/code/tutorial-steps/dev/Dockerfile
+++ b/_includes/tutorials/firewall-splunk/confluent/code/tutorial-steps/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-server-connect-base:7.1.0
+FROM confluentinc/cp-server-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/firewall-splunk/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/firewall-splunk/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/fk-joins/kstreams/code/build.gradle
+++ b/_includes/tutorials/fk-joins/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
-  implementation "org.slf4j:slf4j-simple:2.0.3"
+  implementation "org.slf4j:slf4j-simple:2.0.5"
   implementation "org.apache.kafka:kafka-streams:3.3.1"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/fk-joins/kstreams/code/build.gradle
+++ b/_includes/tutorials/fk-joins/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.3"
-  implementation "org.apache.kafka:kafka-streams:3.1.0"
-  implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
   testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/fk-joins/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/fk-joins/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/flatten-nested-data/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/flatten-nested-data/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/fleet-management/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/fleet-management/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/generate-test-data-streams/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/generate-test-data-streams/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   connect:
-    image: confluentinc/cp-kafka-connect-base:7.1.0
+    image: confluentinc/cp-kafka-connect-base:7.3.0
     container_name: connect
     depends_on:
       - broker

--- a/_includes/tutorials/generate-test-data-streams/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/generate-test-data-streams/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb
     container_name: ksqldb
     depends_on:
@@ -91,7 +91,7 @@ services:
         sleep infinity
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/geo-distance/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/geo-distance/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0      
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/hopping-windows/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/hopping-windows/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
       
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/internet-of-things/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/internet-of-things/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/inventory/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/inventory/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/iot-asset-tracking/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/iot-asset-tracking/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/joining-stream-stream/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/joining-stream-stream/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/joining-stream-table/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/joining-stream-table/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.3'
-  implementation 'org.apache.kafka:kafka-streams:3.1.0'
-  implementation 'io.confluent:kafka-streams-avro-serde:7.1.0'
-  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.1.0'
+  implementation 'org.apache.kafka:kafka-streams:3.3.1'
+  implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
+  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
-  implementation 'org.slf4j:slf4j-simple:2.0.3'
+  implementation 'org.slf4j:slf4j-simple:2.0.5'
   implementation 'org.apache.kafka:kafka-streams:3.3.1'
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'

--- a/_includes/tutorials/joining-stream-table/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/joining-table-table/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/joining-table-table/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0      
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/kafka-connect-datagen/kafka/code/Dockerfile
+++ b/_includes/tutorials/kafka-connect-datagen/kafka/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:7.1.0
+FROM confluentinc/cp-kafka-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/kafka-connect-datagen/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/kafka-connect-datagen/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
@@ -29,7 +29,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-clients:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
@@ -29,7 +29,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
@@ -30,8 +30,8 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
@@ -29,7 +29,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-clients:3.3.1"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/kafka-producer-application/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/Dockerfile-connect
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/Dockerfile-connect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:7.1.0
+FROM confluentinc/cp-kafka-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/build.gradle
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/build.gradle
@@ -31,7 +31,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.1.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"

--- a/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/kafka-streams-schedule-operations/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/ksql-heterogeneous-json/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/ksql-heterogeneous-json/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -62,7 +62,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/ksql-nested-json/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/ksql-nested-json/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -62,7 +62,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/location-based-alerting/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/location-based-alerting/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/logistics/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/logistics/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/loyalty-rewards/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/loyalty-rewards/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/mainframe-offload/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/mainframe-offload/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/masking-data/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/masking-data/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/merging/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/merging/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/merging/kstreams/code/build.gradle
+++ b/_includes/tutorials/merging/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/merging/kstreams/code/build.gradle
+++ b/_includes/tutorials/merging/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/merging/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/merging/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/message-ordering/kafka/code/build.gradle
+++ b/_includes/tutorials/message-ordering/kafka/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/message-ordering/kafka/code/build.gradle
+++ b/_includes/tutorials/message-ordering/kafka/code/build.gradle
@@ -28,7 +28,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/_includes/tutorials/message-ordering/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/message-ordering/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/messaging-modernization/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/messaging-modernization/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/model-retraining/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/model-retraining/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/multi-joins/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/multi-joins/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
+++ b/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
@@ -47,7 +47,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.21.9'
     implementation 'org.apache.avro:avro:1.11.1'
-    implementation 'org.slf4j:slf4j-simple:2.0.3'
+    implementation 'org.slf4j:slf4j-simple:2.0.5'
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
+++ b/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
@@ -48,12 +48,12 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.21.9'
     implementation 'org.apache.avro:avro:1.11.1'
     implementation 'org.slf4j:slf4j-simple:2.0.3'
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
     implementation "io.confluent:kafka-avro-serializer:7.1.4"
     implementation "io.confluent:kafka-protobuf-serializer:7.2.2"
-    implementation "io.confluent:kafka-protobuf-provider:7.1.0"
+    implementation "io.confluent:kafka-protobuf-provider:7.3.0"
 }
 
 protobuf {

--- a/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
+++ b/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
@@ -45,7 +45,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation 'com.google.protobuf:protobuf-java:3.21.9'
+    implementation 'com.google.protobuf:protobuf-java:3.21.10'
     implementation 'org.apache.avro:avro:1.11.1'
     implementation 'org.slf4j:slf4j-simple:2.0.5'
     implementation "org.apache.kafka:kafka-streams:3.3.1"

--- a/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
+++ b/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
@@ -60,7 +60,7 @@ protobuf {
     generatedFilesBaseDir = "${project.buildDir}/generated-main-proto-java"
 
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.21.9'
+        artifact = 'com.google.protobuf:protoc:3.21.10'
     }
 }
 

--- a/_includes/tutorials/multiple-event-types/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/multiple-event-types/kafka/code/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -32,7 +32,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -33,9 +33,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/next-best-offer/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/next-best-offer/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/omnichannel-commerce/ksql-test/code/Dockerfile
+++ b/_includes/tutorials/omnichannel-commerce/ksql-test/code/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:7.1.0
+FROM confluentinc/cp-kafka-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/omnichannel-commerce/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/omnichannel-commerce/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -32,7 +32,7 @@ services:
       KAFKA_LOG_RETENTION_MS: -1
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -51,7 +51,7 @@ services:
       KSQL_KSQL_CONNECT_URL: "http://connect:8083"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/online-dating/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/online-dating/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/optimize-producer-throughput/confluent/code/tutorial-steps/dev/producer-perf-test-default.sh
+++ b/_includes/tutorials/optimize-producer-throughput/confluent/code/tutorial-steps/dev/producer-perf-test-default.sh
@@ -1,4 +1,4 @@
-docker run -v $PWD/configuration/ccloud.properties:/etc/ccloud.properties confluentinc/cp-server:7.1.0 /usr/bin/kafka-producer-perf-test \
+docker run -v $PWD/configuration/ccloud.properties:/etc/ccloud.properties confluentinc/cp-server:7.3.0 /usr/bin/kafka-producer-perf-test \
     --topic topic-perf \
     --num-records 10000 \
     --record-size 8000 \

--- a/_includes/tutorials/optimize-producer-throughput/confluent/code/tutorial-steps/dev/producer-perf-test-optimized-throughput.sh
+++ b/_includes/tutorials/optimize-producer-throughput/confluent/code/tutorial-steps/dev/producer-perf-test-optimized-throughput.sh
@@ -1,4 +1,4 @@
-docker run -v $PWD/configuration/ccloud.properties:/etc/ccloud.properties confluentinc/cp-server:7.1.0 /usr/bin/kafka-producer-perf-test \
+docker run -v $PWD/configuration/ccloud.properties:/etc/ccloud.properties confluentinc/cp-server:7.3.0 /usr/bin/kafka-producer-perf-test \
     --topic topic-perf \
     --num-records 10000 \
     --record-size 8000 \

--- a/_includes/tutorials/payment-status-check/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/payment-status-check/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/produce-consume-lang/scala/code/build.gradle
+++ b/_includes/tutorials/produce-consume-lang/scala/code/build.gradle
@@ -36,7 +36,7 @@ allprojects {
         implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
         implementation "com.sksamuel.avro4s:avro4s-core_2.13:4.1.0"
         testImplementation "org.scalatest:scalatest_2.13:3.3.0-SNAP3"
-        testImplementation "org.testcontainers:kafka:1.17.5"
+        testImplementation "org.testcontainers:kafka:1.17.6"
 
         // presentation boiler plate
         implementation "com.lihaoyi:cask_2.13:0.8.0"

--- a/_includes/tutorials/produce-consume-lang/scala/code/build.gradle
+++ b/_includes/tutorials/produce-consume-lang/scala/code/build.gradle
@@ -33,7 +33,7 @@ allprojects {
         implementation "org.scala-lang:scala-library:2.13.10"
 
         implementation "org.apache.kafka:kafka-clients:3.1.0"
-        implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
+        implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
         implementation "com.sksamuel.avro4s:avro4s-core_2.13:4.1.0"
         testImplementation "org.scalatest:scalatest_2.13:3.3.0-SNAP3"
         testImplementation "org.testcontainers:kafka:1.17.5"

--- a/_includes/tutorials/produce-consume-lang/scala/code/docker-compose.yml
+++ b/_includes/tutorials/produce-consume-lang/scala/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -15,7 +15,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -33,7 +33,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/produce-consume-lang/scala/code/src/test/scala/io/confluent/developer/KafkaFlatSpec.scala
+++ b/_includes/tutorials/produce-consume-lang/scala/code/src/test/scala/io/confluent/developer/KafkaFlatSpec.scala
@@ -22,7 +22,7 @@ trait KafkaFlatSpec extends AnyFlatSpec
   val testTopics: Vector[TopicSpec]
 
   @Rule
-  val kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.1.0"))
+  val kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.3.0"))
   lazy val admin: Admin = Admin.create(Map[String, AnyRef]("bootstrap.servers" -> kafka.getBootstrapServers).asJava)
 
   override def beforeAll(): Unit = {

--- a/_includes/tutorials/rekeying-function/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/rekeying-function/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -64,7 +64,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/rekeying/ksql/code/Makefile
+++ b/_includes/tutorials/rekeying/ksql/code/Makefile
@@ -11,9 +11,9 @@ tutorial:
 	mkdir $(DEV_OUTPUTS_DIR)
 	mkdir -p $(TEST_OUTPUTS_DIR)
 	harness-runner ../../../../../_data/harnesses/rekeying/ksql.yml $(TEMP_DIR) $(SEQUENCE)
-	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
+	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2-5 $(STEPS_DIR)/dev/expected-print-input.log|sort) <(cut -d ',' -f 2-5 $(DEV_OUTPUTS_DIR)/print-input-topic/output-0.log|sort)"
 	diff --strip-trailing-cr --ignore-space-change $(STEPS_DIR)/dev/expected-describe.log $(DEV_OUTPUTS_DIR)/describe-output/output-0.log
 	# Unless ksqlDB adds support for SLEEP, or we split the docker_ksql_cli_session and insert a bash sleep step (a lot of heavy lifting), this option will hopefully suffice for now. It simply greps out the offending KAFKA_STRING mention in the test at the end.
 	# See https://github.com/confluentinc/kafka-tutorials/issues/510
-	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2- $(STEPS_DIR)/dev/expected-print-output.log|sort) <(cut -d ',' -f 2- $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort|grep -v KAFKA_STRING)"	
+	bash -c "diff --strip-trailing-cr <(cut -d ',' -f 2-5 $(STEPS_DIR)/dev/expected-print-output.log|sort) <(cut -d ',' -f 2-5 $(DEV_OUTPUTS_DIR)/print-output-topic/output-0.log|sort|grep -v KAFKA_STRING)"	
 	reset

--- a/_includes/tutorials/rekeying/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/rekeying/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/rekeying/ksql/code/src/statements.sql
+++ b/_includes/tutorials/rekeying/ksql/code/src/statements.sql
@@ -1,4 +1,4 @@
-CREATE STREAM ratings (old INT KEY, id INT, rating DOUBLE)
+CREATE STREAM ratings (old INT, id INT, rating DOUBLE)
     WITH (kafka_topic='ratings', 
           partitions=2,
           value_format='avro');

--- a/_includes/tutorials/rekeying/ksql/code/test/input.json
+++ b/_includes/tutorials/rekeying/ksql/code/test/input.json
@@ -2,72 +2,72 @@
   "inputs": [
     {
       "topic": "ratings",
-      "key": 1,
       "value": {
+        "old": 1,
         "id": 294,
         "rating": 8.2
       }
     },
     {
       "topic": "ratings",
-      "key": 2,
       "value": {
+        "old": 2,
         "id": 294,
         "rating": 8.5
       }
     },
     {
       "topic": "ratings",
-      "key": 3,
       "value": {
+        "old": 3,
         "id": 354,
         "rating": 9.9
       }
     },
     {
       "topic": "ratings",
-      "key": 4,
       "value": {
+        "old": 4,
         "id": 354,
         "rating": 9.7
       }
     },
     {
       "topic": "ratings",
-      "key": 5,
       "value": {
+        "old": 5,
         "id": 782,
         "rating": 7.8
       }
     },
     {
       "topic": "ratings",
-      "key": 6,
       "value": {
+        "old": 6,
         "id": 782,
         "rating": 7.7
       }
     },
     {
       "topic": "ratings",
-      "key": 7,
       "value": {
+        "old": 7,
         "id": 128,
         "rating": 8.7
       }
     },
     {
       "topic": "ratings",
-      "key": 8,
       "value": {
+        "old": 8,
         "id": 128,
         "rating": 8.4
       }
     },
     {
       "topic": "ratings",
-      "key": 9,
       "value": {
+        "old": 9,
         "id": 780,
         "rating": 2.1
       }

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/create-ratings-stream.sql
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/create-ratings-stream.sql
@@ -1,4 +1,4 @@
-CREATE STREAM ratings (old INT KEY, id INT, rating DOUBLE)
+CREATE STREAM ratings (old INT, id INT, rating DOUBLE)
     WITH (kafka_topic='ratings', 
           partitions=2, 
           value_format='avro');

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-describe.log
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-describe.log
@@ -2,7 +2,7 @@ Name                 : RATINGS_REKEYED
  Field  | Type
 
  ID     | INTEGER          (key)
- RATING | DOUBLE
  OLD    | INTEGER
+ RATING | DOUBLE
 
 For runtime statistics and query details run: DESCRIBE <Stream,Table> EXTENDED;

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-input.log
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-input.log
@@ -1,12 +1,12 @@
-Key format: KAFKA_INT or KAFKA_STRING
+Key format: ¯\_(ツ)_/¯ - no data processed
 Value format: AVRO
-rowtime: 2020/05/04 23:24:30.376 Z, key: 1, value: {"ID": 294, "RATING": 8.2}, partition: 0
-rowtime: 2020/05/04 23:24:30.684 Z, key: 2, value: {"ID": 294, "RATING": 8.5}, partition: 1
-rowtime: 2020/05/04 23:24:30.781 Z, key: 3, value: {"ID": 354, "RATING": 9.9}, partition: 1
-rowtime: 2020/05/04 23:24:30.949 Z, key: 4, value: {"ID": 354, "RATING": 9.7}, partition: 1
-rowtime: 2020/05/04 23:24:31.099 Z, key: 5, value: {"ID": 782, "RATING": 7.8}, partition: 0
-rowtime: 2020/05/04 23:24:30.560 Z, key: 6, value: {"ID": 782, "RATING": 7.7}, partition: 1
-rowtime: 2020/05/04 23:24:30.873 Z, key: 7, value: {"ID": 128, "RATING": 8.7}, partition: 1
-rowtime: 2020/05/04 23:24:31.021 Z, key: 8, value: {"ID": 128, "RATING": 8.4}, partition: 0
-rowtime: 2020/05/04 23:24:31.178 Z, key: 9, value: {"ID": 780, "RATING": 2.1}, partition: 0
+rowtime: 2022/12/02 21:56:48.720 Z, key: <null>, value: {"OLD": 2, "ID": 294, "RATING": 8.5}, partition: 0
+rowtime: 2022/12/02 21:56:48.829 Z, key: <null>, value: {"OLD": 5, "ID": 782, "RATING": 7.8}, partition: 1
+rowtime: 2022/12/02 21:56:48.875 Z, key: <null>, value: {"OLD": 6, "ID": 782, "RATING": 7.7}, partition: 1
+rowtime: 2022/12/02 21:56:48.946 Z, key: <null>, value: {"OLD": 8, "ID": 128, "RATING": 8.4}, partition: 1
+rowtime: 2022/12/02 21:56:48.652 Z, key: <null>, value: {"OLD": 1, "ID": 294, "RATING": 8.2}, partition: 1
+rowtime: 2022/12/02 21:56:48.757 Z, key: <null>, value: {"OLD": 3, "ID": 354, "RATING": 9.9}, partition: 1
+rowtime: 2022/12/02 21:56:48.793 Z, key: <null>, value: {"OLD": 4, "ID": 354, "RATING": 9.7}, partition: 1
+rowtime: 2022/12/02 21:56:48.910 Z, key: <null>, value: {"OLD": 7, "ID": 128, "RATING": 8.7}, partition: 1
+rowtime: 2022/12/02 21:56:48.982 Z, key: <null>, value: {"OLD": 9, "ID": 780, "RATING": 2.1}, partition: 1
 Topic printing ceased

--- a/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-output.log
+++ b/_includes/tutorials/rekeying/ksql/code/tutorial-steps/dev/expected-print-output.log
@@ -1,12 +1,12 @@
 Key format: KAFKA_INT
 Value format: AVRO
-rowtime: 2020/05/04 23:24:30.376 Z, key: 128, value: {"RATING": 8.4, "OLD": 8}, partition: 0
-rowtime: 2020/05/04 23:24:30.684 Z, key: 128, value: {"RATING": 8.7, "OLD": 7}, partition: 0
-rowtime: 2020/05/04 23:24:30.781 Z, key: 294, value: {"RATING": 8.2, "OLD": 1}, partition: 0
-rowtime: 2020/05/04 23:24:30.949 Z, key: 294, value: {"RATING": 8.5, "OLD": 2}, partition: 0
-rowtime: 2020/05/04 23:24:31.099 Z, key: 354, value: {"RATING": 9.7, "OLD": 4}, partition: 0
-rowtime: 2020/05/04 23:24:30.560 Z, key: 354, value: {"RATING": 9.9, "OLD": 3}, partition: 0
-rowtime: 2020/05/04 23:24:30.873 Z, key: 780, value: {"RATING": 2.1, "OLD": 9}, partition: 1
-rowtime: 2020/05/04 23:24:31.021 Z, key: 782, value: {"RATING": 7.7, "OLD": 6}, partition: 0
-rowtime: 2020/05/04 23:24:31.178 Z, key: 782, value: {"RATING": 7.8, "OLD": 5}, partition: 0
+rowtime: 2020/05/04 23:24:30.376 Z, key: 128, value: {"OLD": 8, "RATING": 8.4}, partition: 0
+rowtime: 2020/05/04 23:24:30.684 Z, key: 128, value: {"OLD": 7, "RATING": 8.7}, partition: 0
+rowtime: 2020/05/04 23:24:30.781 Z, key: 294, value: {"OLD": 1, "RATING": 8.2}, partition: 0
+rowtime: 2020/05/04 23:24:30.949 Z, key: 294, value: {"OLD": 2, "RATING": 8.5}, partition: 0
+rowtime: 2020/05/04 23:24:31.099 Z, key: 354, value: {"OLD": 4, "RATING": 9.7}, partition: 0
+rowtime: 2020/05/04 23:24:30.560 Z, key: 354, value: {"OLD": 3, "RATING": 9.9}, partition: 0
+rowtime: 2020/05/04 23:24:30.873 Z, key: 780, value: {"OLD": 9, "RATING": 2.1}, partition: 1
+rowtime: 2020/05/04 23:24:31.021 Z, key: 782, value: {"OLD": 6, "RATING": 7.7}, partition: 0
+rowtime: 2020/05/04 23:24:31.178 Z, key: 782, value: {"OLD": 5, "RATING": 7.8}, partition: 0
 Topic printing ceased

--- a/_includes/tutorials/salesforce/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/salesforce/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     implementation "com.fasterxml.jackson.core:jackson-core:2.14.1"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.1"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.0"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.1"
 
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "io.confluent:common-utils:7.3.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     implementation "com.fasterxml.jackson.core:jackson-core:2.14.1"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.0"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.1"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.14.0"
 
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "org.apache.kafka:kafka-streams:3.1.0"
     implementation "io.confluent:common-utils:7.3.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.14.0"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.14.1"
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.14.0"
 

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/build.gradle
@@ -28,7 +28,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.1.0"
     implementation "io.confluent:common-utils:7.3.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/code/build.gradle
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/code/build.gradle
@@ -28,7 +28,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
 
     implementation "org.apache.kafka:kafka-streams:3.1.0"
     implementation "io.confluent:common-utils:7.3.0"

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:

--- a/_includes/tutorials/serialization/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/serialization/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/serialization/kstreams/code/build.gradle
+++ b/_includes/tutorials/serialization/kstreams/code/build.gradle
@@ -75,7 +75,7 @@ protobuf {
   generatedFilesBaseDir = "$buildDir/generated-main-proto-java/"
 
   protoc {
-    artifact = "com.google.protobuf:protoc:3.21.9"
+    artifact = "com.google.protobuf:protoc:3.21.10"
   }
 
 }

--- a/_includes/tutorials/serialization/kstreams/code/build.gradle
+++ b/_includes/tutorials/serialization/kstreams/code/build.gradle
@@ -35,12 +35,12 @@ dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "com.google.protobuf:protobuf-java:3.21.9"
   implementation "org.slf4j:slf4j-simple:2.0.3"
-  implementation "org.apache.kafka:kafka-streams:3.1.0"
-  implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-  implementation "io.confluent:kafka-streams-protobuf-serde:7.1.0"
+  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+  implementation "io.confluent:kafka-streams-protobuf-serde:7.3.0"
   implementation 'com.google.code.gson:gson:2.10'
 
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/_includes/tutorials/serialization/kstreams/code/build.gradle
+++ b/_includes/tutorials/serialization/kstreams/code/build.gradle
@@ -34,7 +34,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "com.google.protobuf:protobuf-java:3.21.9"
-  implementation "org.slf4j:slf4j-simple:2.0.3"
+  implementation "org.slf4j:slf4j-simple:2.0.5"
   implementation "org.apache.kafka:kafka-streams:3.3.1"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation "io.confluent:kafka-streams-protobuf-serde:7.3.0"

--- a/_includes/tutorials/serialization/kstreams/code/build.gradle
+++ b/_includes/tutorials/serialization/kstreams/code/build.gradle
@@ -33,7 +33,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
-  implementation "com.google.protobuf:protobuf-java:3.21.9"
+  implementation "com.google.protobuf:protobuf-java:3.21.10"
   implementation "org.slf4j:slf4j-simple:2.0.5"
   implementation "org.apache.kafka:kafka-streams:3.3.1"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"

--- a/_includes/tutorials/serialization/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/serialization/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/session-windows/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/session-windows/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb
     container_name: ksqldb
     depends_on:

--- a/_includes/tutorials/session-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/session-windows/kstreams/code/build.gradle
@@ -30,7 +30,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"

--- a/_includes/tutorials/session-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/session-windows/kstreams/code/build.gradle
@@ -31,10 +31,10 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/session-windows/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/session-windows/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/sliding-windows/kstreams/code/Dockerfile-connect
+++ b/_includes/tutorials/sliding-windows/kstreams/code/Dockerfile-connect
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka-connect-base:7.1.0
+FROM confluentinc/cp-kafka-connect-base:7.3.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
@@ -31,7 +31,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     implementation('io.confluent:kafka-streams-avro-serde:7.3.0')
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
@@ -32,9 +32,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation('io.confluent:kafka-streams-avro-serde:7.1.0')
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation('io.confluent:kafka-streams-avro-serde:7.3.0')
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/sliding-windows/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/sliding-windows/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/splitting/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/splitting/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/splitting/kstreams/code/build.gradle
+++ b/_includes/tutorials/splitting/kstreams/code/build.gradle
@@ -30,7 +30,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
-  implementation "org.slf4j:slf4j-simple:2.0.3"
+  implementation "org.slf4j:slf4j-simple:2.0.5"
   implementation "org.apache.kafka:kafka-streams:3.3.1"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"

--- a/_includes/tutorials/splitting/kstreams/code/build.gradle
+++ b/_includes/tutorials/splitting/kstreams/code/build.gradle
@@ -31,9 +31,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.3"
-  implementation "org.apache.kafka:kafka-streams:3.1.0"
-  implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
   testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/splitting/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/splitting/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ repositories {
 apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
-    implementation "org.slf4j:slf4j-simple:2.0.3"
+    implementation "org.slf4j:slf4j-simple:2.0.5"
     implementation "org.apache.kafka:kafka-streams:3.3.1"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
@@ -30,8 +30,8 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.3"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/streams-to-table/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/streams-to-table/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
       
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/survey-responses/ksql-test/code/docker-compose.yml
+++ b/_includes/tutorials/survey-responses/ksql-test/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -48,7 +48,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/time-concepts/ksql/code/build.gradle
+++ b/_includes/tutorials/time-concepts/ksql/code/build.gradle
@@ -32,9 +32,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.0"
     implementation "org.slf4j:slf4j-simple:1.7.30"
-    implementation "org.apache.kafka:kafka-streams:3.1.0"
-    implementation "io.confluent:kafka-streams-avro-serde:7.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
     testImplementation "junit:junit:4.13.1"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/time-concepts/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/time-concepts/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -62,7 +62,7 @@ services:
       KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/transforming/kafka/code/build.gradle
+++ b/_includes/tutorials/transforming/kafka/code/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   implementation 'org.slf4j:slf4j-simple:2.0.3'
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'junit:junit:4.13.2'
-  testImplementation "org.testcontainers:kafka:1.17.5"
+  testImplementation "org.testcontainers:kafka:1.17.6"
 }
 
 test {

--- a/_includes/tutorials/transforming/kafka/code/build.gradle
+++ b/_includes/tutorials/transforming/kafka/code/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
-  implementation 'org.slf4j:slf4j-simple:2.0.3'
+  implementation 'org.slf4j:slf4j-simple:2.0.5'
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'junit:junit:4.13.2'
   testImplementation "org.testcontainers:kafka:1.17.6"

--- a/_includes/tutorials/transforming/kafka/code/build.gradle
+++ b/_includes/tutorials/transforming/kafka/code/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.3'
-  implementation 'io.confluent:kafka-streams-avro-serde:7.1.0'
+  implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'junit:junit:4.13.2'
   testImplementation "org.testcontainers:kafka:1.17.5"
 }

--- a/_includes/tutorials/transforming/kafka/code/configuration/test.properties
+++ b/_includes/tutorials/transforming/kafka/code/configuration/test.properties
@@ -1,4 +1,4 @@
-confluent.version=7.1.0
+confluent.version=7.3.0
 bootstrap.servers=localhost:29092
 schema.registry.url=mock://localhost:8081
 

--- a/_includes/tutorials/transforming/kafka/code/docker-compose.yml
+++ b/_includes/tutorials/transforming/kafka/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/transforming/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/transforming/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/transforming/kstreams/code/build.gradle
+++ b/_includes/tutorials/transforming/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.3'
-  implementation 'org.apache.kafka:kafka-streams:3.1.0'
-  implementation 'io.confluent:kafka-streams-avro-serde:7.1.0'
-  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.1.0'
+  implementation 'org.apache.kafka:kafka-streams:3.3.1'
+  implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
+  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/_includes/tutorials/transforming/kstreams/code/build.gradle
+++ b/_includes/tutorials/transforming/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
-  implementation 'org.slf4j:slf4j-simple:2.0.3'
+  implementation 'org.slf4j:slf4j-simple:2.0.5'
   implementation 'org.apache.kafka:kafka-streams:3.3.1'
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'

--- a/_includes/tutorials/transforming/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/transforming/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/tumbling-windows/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/tumbling-windows/ksql/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,7 +31,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -43,7 +43,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -61,7 +61,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.3'
-  implementation 'org.apache.kafka:kafka-streams:3.1.0'
-  implementation 'io.confluent:kafka-streams-avro-serde:7.1.0'
-  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.1.0'
+  implementation 'org.apache.kafka:kafka-streams:3.3.1'
+  implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
+  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
-  implementation 'org.slf4j:slf4j-simple:2.0.3'
+  implementation 'org.slf4j:slf4j-simple:2.0.5'
   implementation 'org.apache.kafka:kafka-streams:3.3.1'
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'

--- a/_includes/tutorials/tumbling-windows/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/_includes/tutorials/udf/ksql/code/docker-compose.yml
+++ b/_includes/tutorials/udf/ksql/code/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -12,7 +12,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -30,7 +30,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -42,7 +42,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:9092'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:0.24.0
+    image: confluentinc/ksqldb-server:0.28.2
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -63,7 +63,7 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:0.24.0
+    image: confluentinc/ksqldb-cli:0.28.2
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/_includes/tutorials/window-final-result/kstreams/code/docker-compose.yml
+++ b/_includes/tutorials/window-final-result/kstreams/code/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.1.0
+    image: confluentinc/cp-zookeeper:7.3.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:7.1.0
+    image: confluentinc/cp-kafka:7.3.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -29,7 +29,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.1.0
+    image: confluentinc/cp-schema-registry:7.3.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/templates/kafka/filtered/kafka-test-harness-template.yml
+++ b/templates/kafka/filtered/kafka-test-harness-template.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/templates/ksql/filtered/ksql-test-harness-template.yml
+++ b/templates/ksql/filtered/ksql-test-harness-template.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/templates/kstreams/filtered/kstreams-test-harness-template.yml
+++ b/templates/kstreams/filtered/kstreams-test-harness-template.yml
@@ -1,5 +1,11 @@
 dev:
   steps:
+    - title: Prerequisites
+      content:
+        - action: skip
+          render:
+            file: shared/markup/dev/docker-prerequisite.adoc
+
     - title: Initialize the project
       content:
         - action: execute

--- a/tools/docker-compose.override.yml
+++ b/tools/docker-compose.override.yml
@@ -8,7 +8,7 @@ version: "2"
 services:
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:7.1.0
+    image: confluentinc/cp-enterprise-control-center:7.3.0
     hostname: control-center
     container_name: control-center
     ports:
@@ -26,7 +26,7 @@ services:
       PORT: 9021
 
   broker:
-    image: confluentinc/cp-server:7.1.0
+    image: confluentinc/cp-server:7.3.0
     environment:
       KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
       CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:9092


### PR DESCRIPTION
### Description

This release contains:

- [upgrade CP to 7.3.0](https://github.com/confluentinc/kafka-tutorials/pull/1470/commits/560c290c276f8d333fadea52e8d4c652bfa28647)
- [add Docker instructions to tutorials that run CP with Docker Compose](https://github.com/confluentinc/kafka-tutorials/pull/1470/commits/1455f8104524090b79fcb935f4bc12dde24c1fbc)
- Various dependency upgrades 
- Build improvement (parallelized tests) 

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/master/

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
