### PR TITLE
[WIP]: DO NOT MERGE Kstreams change should trigger only two blocks

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -99,6 +99,8 @@ blocks:
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
     dependencies: ["Build the website"]
+    run:
+      when: "change_in(['_includes/tutorials/*/kstreams', '_includes/tutorials/*/kafka', '_includes/tutorials/*/scala'])"
     task:
       prologue:
         commands:
@@ -115,6 +117,8 @@ blocks:
 
   - name: Run first block of tests (mostly Kafka and KStreams)
     dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
+    run:
+      when: "change_in(['_includes/tutorials/*/kstreams', '_includes/tutorials/*/kafka', '_includes/tutorials/*/scala'])"
     execution_time_limit:
       minutes: 20
     task:
@@ -289,6 +293,8 @@ blocks:
 
   - name: Run second block of tests (ksqlDB recipes)
     dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
+    run:
+      when: "change_in('_includes/tutorials/*/ksql-test')"
     execution_time_limit:
       minutes: 20
     task:
@@ -414,6 +420,8 @@ blocks:
 
   - name: Run third block of tests (mostly ksqlDB)
     dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
+    run:
+      when: "change_in('_includes/tutorials/*/ksql')"
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -98,7 +98,7 @@ blocks:
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
     run:
-      when: "change_in(['/_includes/tutorials/**/kstreams/', '/_includes/tutorials/**/kafka/', '/_includes/tutorials/**/scala/'])"
+      when: "change_in(['_includes/tutorials/**/kstreams/', '_includes/tutorials/**/kafka/', '_includes/tutorials/**/scala/'])"
     task:
       prologue:
         commands:
@@ -115,7 +115,7 @@ blocks:
 
   - name: Run first block of tests (mostly Kafka and KStreams)
     run:
-      when: "change_in(['/_includes/tutorials/**/kstreams/', '/_includes/tutorials/**/kafka/', '/_includes/tutorials/**/scala/'])"
+      when: "change_in(['_includes/tutorials/**/kstreams/', '_includes/tutorials/**/kafka/', '_includes/tutorials/**/scala/'])"
     execution_time_limit:
       minutes: 20
     task:
@@ -290,7 +290,7 @@ blocks:
 
   - name: Run second block of tests (ksqlDB recipes)
     run:
-      when: "change_in('/_includes/tutorials/**/ksql-test/')"
+      when: "change_in('_includes/tutorials/**/ksql-test/')"
     execution_time_limit:
       minutes: 20
     task:
@@ -416,7 +416,7 @@ blocks:
 
   - name: Run third block of tests (mostly ksqlDB)
     run:
-      when: "change_in('/_includes/tutorials/**/ksql/')"
+      when: "change_in('_includes/tutorials/**/ksql/')"
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -98,7 +98,7 @@ blocks:
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams/**', '_includes/tutorials/**/kafka/**', '_includes/tutorials/**/scala/**'], {pipeline_file: 'ignore'})"
+      when: "change_in(['_includes/tutorials/**/kstreams/**/', '_includes/tutorials/**/kafka/**/', '_includes/tutorials/**/scala/**/'], {pipeline_file: 'ignore'})"
     task:
       prologue:
         commands:
@@ -115,7 +115,7 @@ blocks:
 
   - name: Run first block of tests (mostly Kafka and KStreams)
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams/**', '_includes/tutorials/**/kafka/**', '_includes/tutorials/**/scala/**'], {pipeline_file: 'ignore'})"
+      when: "change_in(['_includes/tutorials/**/kstreams/**/', '_includes/tutorials/**/kafka/**/', '_includes/tutorials/**/scala/**/'], {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:
@@ -290,7 +290,7 @@ blocks:
 
   - name: Run second block of tests (ksqlDB recipes)
     run:
-      when: "change_in('_includes/tutorials/**/ksql-test/**', {pipeline_file: 'ignore'})"
+      when: "change_in('_includes/tutorials/**/ksql-test/**/', {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:
@@ -416,7 +416,7 @@ blocks:
 
   - name: Run third block of tests (mostly ksqlDB)
     run:
-      when: "change_in('_includes/tutorials/**/ksql/**', {pipeline_file: 'ignore'})"
+      when: "change_in('_includes/tutorials/**/ksql/**/', {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -98,7 +98,7 @@ blocks:
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams/', '_includes/tutorials/**/kafka/', '_includes/tutorials/**/scala/'])"
+      when: "change_in(['_includes/tutorials/**/kstreams/**', '_includes/tutorials/**/kafka/**', '_includes/tutorials/**/scala/**'], {pipeline_file: 'ignore'})"
     task:
       prologue:
         commands:
@@ -115,7 +115,7 @@ blocks:
 
   - name: Run first block of tests (mostly Kafka and KStreams)
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams/', '_includes/tutorials/**/kafka/', '_includes/tutorials/**/scala/'])"
+      when: "change_in(['_includes/tutorials/**/kstreams/**', '_includes/tutorials/**/kafka/**', '_includes/tutorials/**/scala/**'], {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:
@@ -290,7 +290,7 @@ blocks:
 
   - name: Run second block of tests (ksqlDB recipes)
     run:
-      when: "change_in('_includes/tutorials/**/ksql-test/')"
+      when: "change_in('_includes/tutorials/**/ksql-test/**', {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:
@@ -416,7 +416,7 @@ blocks:
 
   - name: Run third block of tests (mostly ksqlDB)
     run:
-      when: "change_in('_includes/tutorials/**/ksql/')"
+      when: "change_in('_includes/tutorials/**/ksql/**', {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -98,7 +98,7 @@ blocks:
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams/**/*', '_includes/tutorials/**/kafka/**/*', '_includes/tutorials/**/scala/**/*'], {pipeline_file: 'ignore'})"
+      when: "change_in(['_includes/tutorials/*/kstreams/**/*', '_includes/tutorials/*/kafka/**/*', '_includes/tutorials/*/scala/**/*'], {pipeline_file: 'ignore'})"
     task:
       prologue:
         commands:
@@ -115,7 +115,7 @@ blocks:
 
   - name: Run first block of tests (mostly Kafka and KStreams)
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams/**/*', '_includes/tutorials/**/kafka/**/*', '_includes/tutorials/**/scala/**/*'], {pipeline_file: 'ignore'})"
+      when: "change_in(['_includes/tutorials/*/kstreams/**/*', '_includes/tutorials/*/kafka/**/*', '_includes/tutorials/*/scala/**/*'], {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:
@@ -290,7 +290,7 @@ blocks:
 
   - name: Run second block of tests (ksqlDB recipes)
     run:
-      when: "change_in('_includes/tutorials/**/ksql-test/**/*', {pipeline_file: 'ignore'})"
+      when: "change_in('_includes/tutorials/*/ksql-test/**/*', {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:
@@ -416,7 +416,7 @@ blocks:
 
   - name: Run third block of tests (mostly ksqlDB)
     run:
-      when: "change_in('_includes/tutorials/**/ksql/**/*', {pipeline_file: 'ignore'})"
+      when: "change_in('_includes/tutorials/*/ksql/**/*', {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,7 +80,6 @@ promotions:
 
 blocks:
   - name: Build the website
-    dependencies: []
     task:
       prologue:
         commands:
@@ -98,7 +97,6 @@ blocks:
             - cache store site-$SEMAPHORE_GIT_SHA _site
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
-    dependencies: ["Build the website"]
     run:
       when: "change_in(['_includes/tutorials/*/kstreams', '_includes/tutorials/*/kafka', '_includes/tutorials/*/scala'])"
     task:
@@ -116,7 +114,6 @@ blocks:
             - ./gradlew clean test
 
   - name: Run first block of tests (mostly Kafka and KStreams)
-    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     run:
       when: "change_in(['_includes/tutorials/*/kstreams', '_includes/tutorials/*/kafka', '_includes/tutorials/*/scala'])"
     execution_time_limit:
@@ -292,7 +289,6 @@ blocks:
             - make -C _includes/tutorials/confluent-parallel-consumer-application/kafka/code tutorial
 
   - name: Run second block of tests (ksqlDB recipes)
-    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     run:
       when: "change_in('_includes/tutorials/*/ksql-test')"
     execution_time_limit:
@@ -419,7 +415,6 @@ blocks:
             - make -C _includes/tutorials/omnichannel-commerce/ksql-test/code tutorial
 
   - name: Run third block of tests (mostly ksqlDB)
-    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
     run:
       when: "change_in('_includes/tutorials/*/ksql')"
     execution_time_limit:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -98,7 +98,7 @@ blocks:
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams/**/', '_includes/tutorials/**/kafka/**/', '_includes/tutorials/**/scala/**/'], {pipeline_file: 'ignore'})"
+      when: "change_in(['_includes/tutorials/**/kstreams/**/*', '_includes/tutorials/**/kafka/**/*', '_includes/tutorials/**/scala/**/*'], {pipeline_file: 'ignore'})"
     task:
       prologue:
         commands:
@@ -115,7 +115,7 @@ blocks:
 
   - name: Run first block of tests (mostly Kafka and KStreams)
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams/**/', '_includes/tutorials/**/kafka/**/', '_includes/tutorials/**/scala/**/'], {pipeline_file: 'ignore'})"
+      when: "change_in(['_includes/tutorials/**/kstreams/**/*', '_includes/tutorials/**/kafka/**/*', '_includes/tutorials/**/scala/**/*'], {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:
@@ -290,7 +290,7 @@ blocks:
 
   - name: Run second block of tests (ksqlDB recipes)
     run:
-      when: "change_in('_includes/tutorials/**/ksql-test/**/', {pipeline_file: 'ignore'})"
+      when: "change_in('_includes/tutorials/**/ksql-test/**/*', {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:
@@ -416,7 +416,7 @@ blocks:
 
   - name: Run third block of tests (mostly ksqlDB)
     run:
-      when: "change_in('_includes/tutorials/**/ksql/**/', {pipeline_file: 'ignore'})"
+      when: "change_in('_includes/tutorials/**/ksql/**/*', {pipeline_file: 'ignore'})"
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -98,7 +98,7 @@ blocks:
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams', '_includes/tutorials/**/kafka', '_includes/tutorials/**/scala'])"
+      when: "change_in(['/_includes/tutorials/**/kstreams/', '/_includes/tutorials/**/kafka/', '/_includes/tutorials/**/scala/'])"
     task:
       prologue:
         commands:
@@ -115,7 +115,7 @@ blocks:
 
   - name: Run first block of tests (mostly Kafka and KStreams)
     run:
-      when: "change_in(['_includes/tutorials/**/kstreams', '_includes/tutorials/**/kafka', '_includes/tutorials/**/scala'])"
+      when: "change_in(['/_includes/tutorials/**/kstreams/', '/_includes/tutorials/**/kafka/', '/_includes/tutorials/**/scala/'])"
     execution_time_limit:
       minutes: 20
     task:
@@ -290,7 +290,7 @@ blocks:
 
   - name: Run second block of tests (ksqlDB recipes)
     run:
-      when: "change_in('_includes/tutorials/**/ksql-test')"
+      when: "change_in('/_includes/tutorials/**/ksql-test/')"
     execution_time_limit:
       minutes: 20
     task:
@@ -416,7 +416,7 @@ blocks:
 
   - name: Run third block of tests (mostly ksqlDB)
     run:
-      when: "change_in('_includes/tutorials/**/ksql')"
+      when: "change_in('/_includes/tutorials/**/ksql/')"
     execution_time_limit:
       minutes: 20
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -98,7 +98,7 @@ blocks:
 
   - name: "☕️ Build and Test Java (Kafka and Kafka Streams) Only"
     run:
-      when: "change_in(['_includes/tutorials/*/kstreams', '_includes/tutorials/*/kafka', '_includes/tutorials/*/scala'])"
+      when: "change_in(['_includes/tutorials/**/kstreams', '_includes/tutorials/**/kafka', '_includes/tutorials/**/scala'])"
     task:
       prologue:
         commands:
@@ -115,7 +115,7 @@ blocks:
 
   - name: Run first block of tests (mostly Kafka and KStreams)
     run:
-      when: "change_in(['_includes/tutorials/*/kstreams', '_includes/tutorials/*/kafka', '_includes/tutorials/*/scala'])"
+      when: "change_in(['_includes/tutorials/**/kstreams', '_includes/tutorials/**/kafka', '_includes/tutorials/**/scala'])"
     execution_time_limit:
       minutes: 20
     task:
@@ -290,7 +290,7 @@ blocks:
 
   - name: Run second block of tests (ksqlDB recipes)
     run:
-      when: "change_in('_includes/tutorials/*/ksql-test')"
+      when: "change_in('_includes/tutorials/**/ksql-test')"
     execution_time_limit:
       minutes: 20
     task:
@@ -416,7 +416,7 @@ blocks:
 
   - name: Run third block of tests (mostly ksqlDB)
     run:
-      when: "change_in('_includes/tutorials/*/ksql')"
+      when: "change_in('_includes/tutorials/**/ksql')"
     execution_time_limit:
       minutes: 20
     task:

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
@@ -44,7 +44,7 @@ public class CogroupingStreams {
 
     public Topology buildTopology(Properties allProps) {
         // Touching the file to trigger a build - should only trigger one section
-        // Another change
+        // Another change please trigger a build
         final StreamsBuilder builder = new StreamsBuilder();
         final String appOneInputTopic = allProps.getProperty("app-one.topic.name");
         final String appTwoInputTopic = allProps.getProperty("app-two.topic.name");

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
@@ -43,6 +43,7 @@ public class CogroupingStreams {
 
 
     public Topology buildTopology(Properties allProps) {
+        //Touching the file to trigger a build
         final StreamsBuilder builder = new StreamsBuilder();
         final String appOneInputTopic = allProps.getProperty("app-one.topic.name");
         final String appTwoInputTopic = allProps.getProperty("app-two.topic.name");

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
@@ -43,7 +43,7 @@ public class CogroupingStreams {
 
 
     public Topology buildTopology(Properties allProps) {
-        //Touching the file to trigger a build
+        // Touching the file to trigger a build - should only trigger one section
         final StreamsBuilder builder = new StreamsBuilder();
         final String appOneInputTopic = allProps.getProperty("app-one.topic.name");
         final String appTwoInputTopic = allProps.getProperty("app-two.topic.name");

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
@@ -44,6 +44,7 @@ public class CogroupingStreams {
 
     public Topology buildTopology(Properties allProps) {
         // Touching the file to trigger a build - should only trigger one section
+        // Another change
         final StreamsBuilder builder = new StreamsBuilder();
         final String appOneInputTopic = allProps.getProperty("app-one.topic.name");
         final String appTwoInputTopic = allProps.getProperty("app-two.topic.name");

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
@@ -43,8 +43,7 @@ public class CogroupingStreams {
 
 
     public Topology buildTopology(Properties allProps) {
-        // Touching the file to trigger a build - should only trigger one section
-        // Another change please trigger a build
+        // This is a dummy change
         final StreamsBuilder builder = new StreamsBuilder();
         final String appOneInputTopic = allProps.getProperty("app-one.topic.name");
         final String appTwoInputTopic = allProps.getProperty("app-two.topic.name");

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/src/main/java/io/confluent/developer/CogroupingStreams.java
@@ -44,6 +44,7 @@ public class CogroupingStreams {
 
     public Topology buildTopology(Properties allProps) {
         // This is a dummy change
+        // Another change 
         final StreamsBuilder builder = new StreamsBuilder();
         final String appOneInputTopic = allProps.getProperty("app-one.topic.name");
         final String appTwoInputTopic = allProps.getProperty("app-two.topic.name");


### PR DESCRIPTION
### Description

Test PR to see if only the appropriate block of tests run

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
