### PR TITLE
MINOR: Add flink build block

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -581,4 +581,4 @@ blocks:
         commands:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
-      jobs:
+    

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -569,3 +569,16 @@ blocks:
         - name: KSQL rekey stream with function tests
           commands:
             - make -C _includes/tutorials/rekeying-function/ksql/code tutorial
+
+  - name: Run fourth block of tests (FlinkSql or DataStream API)
+    dependencies: ["☕️ Build and Test Java (Kafka and Kafka Streams) Only"]
+    run:
+      when: "(branch = 'master' OR branch = 'release') OR change_in(['../_includes/tutorials/**/flinksql/**/*', '../_data/harnesses/**/flinksql.yml'])"
+    execution_time_limit:
+      minutes: 10
+    task:
+      prologue:
+        commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
+          - sem-version java 17
+      jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -582,7 +582,7 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
       jobs:
-        - name: Flink SQL hopping windows (placeholder)
-          commands:
-            - make -C _includes/tutorials/hopping-windows/flinksql/code tutorial
+        - name: Flink SQL hopping windows
+          commands: #The following is a placeholder and needs updated to a Flink SQL when available
+            - make -C _includes/tutorials/hopping-windows/ksql/code tutorial 
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -581,4 +581,8 @@ blocks:
         commands:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
-    
+      jobs:
+        - name: Flink SQL hopping windows (placeholder)
+          commands:
+            - make -C _includes/tutorials/hopping-windows/flinksql/code tutorial
+


### PR DESCRIPTION
### Description

Adds a separate build block for flink-related tutorials

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
