### PR TITLE
fix: omit backslash from a hero CTA href

### DIFF
--- a/_includes/recipe-content-answer.html
+++ b/_includes/recipe-content-answer.html
@@ -15,7 +15,7 @@
               {% if section.render.skip != true %}
 
         <div class="ctas" data-swiftype-index="false">
-          <a href="https://www.confluent.io/confluent-cloud/tryfree/\?next=tutorials/ksql-recipe-{{ page.static_data }}" class="btn-island">Launch recipe in Confluent Cloud</a>
+          <a href="https://www.confluent.io/confluent-cloud/tryfree/?next=tutorials/ksql-recipe-{{ page.static_data }}" class="btn-island">Launch recipe in Confluent Cloud</a>
         </div>
 
               {% endif %}


### PR DESCRIPTION
### Description
404 Bug fix
a backslash in `Launch recipe in Confluent Cloud` hero CTA causes a 404 in some browsers

Example page: https://developer.confluent.io/tutorials/payment-status-check/confluent.html

Please notify me on slack once this PR is merged <3

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
