### PR TITLE
fix: omit href backslash

### DIFF
--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -70,7 +70,7 @@
           <div class="example-content">
             <div class="text">
                {{ site.data.tutorials[page.static_data].introduction }}
-               <BR><BR>To see this tutorial in action, <a href="https://www.confluent.io/confluent-cloud/tryfree/\?next=tutorials/ksql-recipe-{{ page.static_data }}">click here</a> to launch it now. It will pre-populate the ksqlDB code in the Confluent Cloud Console and provide mock data or stubbed out code to connect to a real data source. For more detailed instructions, follow the steps below.
+               <BR><BR>To see this tutorial in action, <a href="https://www.confluent.io/confluent-cloud/tryfree/?next=tutorials/ksql-recipe-{{ page.static_data }}">click here</a> to launch it now. It will pre-populate the ksqlDB code in the Confluent Cloud Console and provide mock data or stubbed out code to connect to a real data source. For more detailed instructions, follow the steps below.
             </div>
             {% if site.data.tutorials[page.static_data].introduction-media %}
               <img class="image" src="{{ site.data.tutorials[page.static_data].introduction-media | relative_url }}" />


### PR DESCRIPTION
### Description
Resolve 404 errors due to a backslash in `click here` link from  `recipe.html`

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
