### PR TITLE
Update AK versions to 3.4.0

### DIFF
--- a/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "org.apache.kafka:kafka-streams:3.4.0"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation "com.typesafe:config:1.4.2"
 
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"
   testImplementation 'org.hamcrest:hamcrest:2.2'
 

--- a/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-average/kstreams/code/build.gradle
@@ -31,7 +31,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.4.0"
+  implementation 'org.apache.kafka:kafka-streams:3.4.0'
+  implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation "com.typesafe:config:1.4.2"
 

--- a/_includes/tutorials/aggregating-average/kstreams/code/src/main/java/io/confluent/developer/RunningAverage.java
+++ b/_includes/tutorials/aggregating-average/kstreams/code/src/main/java/io/confluent/developer/RunningAverage.java
@@ -61,7 +61,7 @@ public class RunningAverage {
     config.put(REPLICATION_FACTOR_CONFIG, envProps.getProperty("default.topic.replication.factor"));
     config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, envProps.getProperty("offset.reset.policy"));
 
-    config.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    config.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
 
     return config;
   }

--- a/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
@@ -31,9 +31,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
@@ -32,11 +32,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-count/kstreams/code/build.gradle
@@ -31,7 +31,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/aggregating-count/kstreams/code/src/main/java/io/confluent/developer/AggregatingCount.java
+++ b/_includes/tutorials/aggregating-count/kstreams/code/src/main/java/io/confluent/developer/AggregatingCount.java
@@ -100,7 +100,7 @@ public class AggregatingCount {
     }
     allProps.put(StreamsConfig.APPLICATION_ID_CONFIG, allProps.getProperty("application.id"));
     allProps.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
-    allProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    allProps.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
 
     Topology topology = this.buildTopology(allProps, this.ticketSaleSerde(allProps));
     this.createTopics(allProps);

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
@@ -33,7 +33,12 @@ mainClassName = "io.confluent.developer.AggregatingMinMax"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
@@ -34,11 +34,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/build.gradle
@@ -33,9 +33,9 @@ mainClassName = "io.confluent.developer.AggregatingMinMax"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/aggregating-minmax/kstreams/code/src/main/java/io/confluent/developer/AggregatingMinMax.java
+++ b/_includes/tutorials/aggregating-minmax/kstreams/code/src/main/java/io/confluent/developer/AggregatingMinMax.java
@@ -42,7 +42,7 @@ public class AggregatingMinMax {
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, envProps.getProperty("application.id"));
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, envProps.getProperty("bootstrap.servers"));
     props.put(SCHEMA_REGISTRY_URL_CONFIG, envProps.getProperty("schema.registry.url"));
-    props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    props.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
 
     return props;
   }

--- a/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/build.gradle
@@ -30,7 +30,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/aggregating-sum/kstreams/code/src/main/java/io/confluent/developer/AggregatingSum.java
+++ b/_includes/tutorials/aggregating-sum/kstreams/code/src/main/java/io/confluent/developer/AggregatingSum.java
@@ -100,7 +100,7 @@ public class AggregatingSum {
     }
     allProps.put(StreamsConfig.APPLICATION_ID_CONFIG, allProps.getProperty("application.id"));
     allProps.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
-    allProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    allProps.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
 
     Topology topology = this.buildTopology(allProps, this.ticketSaleSerde(allProps));
     this.createTopics(allProps);

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
@@ -32,10 +32,10 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
 
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
@@ -33,11 +33,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
 
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"

--- a/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
+++ b/_includes/tutorials/cogrouping-streams/kstreams/code/build.gradle
@@ -32,7 +32,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
 
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
@@ -32,11 +32,11 @@ dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation 'com.google.code.gson:gson:2.10.1'
 

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "org.apache.kafka:kafka-streams:3.4.0"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation 'com.google.code.gson:gson:2.10.1'
 
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/build.gradle
@@ -31,7 +31,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.4.0"
+  implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation 'com.google.code.gson:gson:2.10.1'
 

--- a/_includes/tutorials/connect-add-key-to-source/kstreams/code/src/main/java/io/confluent/developer/connect/jdbc/specificavro/StreamsIngest.java
+++ b/_includes/tutorials/connect-add-key-to-source/kstreams/code/src/main/java/io/confluent/developer/connect/jdbc/specificavro/StreamsIngest.java
@@ -39,7 +39,7 @@ public class StreamsIngest {
     props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
     props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
     props.put(SCHEMA_REGISTRY_URL_CONFIG, envProps.getProperty("schema.registry.url"));
-    props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    props.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
 
     return props;
   }

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
@@ -35,9 +35,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation 'com.github.javafaker:javafaker:1.0.2'
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
@@ -35,7 +35,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation 'com.github.javafaker:javafaker:1.0.2'
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/kstreams/code/build.gradle
@@ -36,11 +36,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation 'com.github.javafaker:javafaker:1.0.2'
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
@@ -32,9 +32,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
@@ -33,11 +33,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
+++ b/_includes/tutorials/dynamic-output-topic/kstreams/code/build.gradle
@@ -32,7 +32,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -32,7 +32,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"

--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -33,11 +33,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"

--- a/_includes/tutorials/error-handling/kstreams/code/build.gradle
+++ b/_includes/tutorials/error-handling/kstreams/code/build.gradle
@@ -32,10 +32,10 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/filtering/kstreams/code/build.gradle
+++ b/_includes/tutorials/filtering/kstreams/code/build.gradle
@@ -30,7 +30,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.4.0"
+  implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/filtering/kstreams/code/build.gradle
+++ b/_includes/tutorials/filtering/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/filtering/kstreams/code/build.gradle
+++ b/_includes/tutorials/filtering/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "org.apache.kafka:kafka-streams:3.4.0"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/fk-joins/kstreams/code/build.gradle
+++ b/_includes/tutorials/fk-joins/kstreams/code/build.gradle
@@ -30,7 +30,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.4.0"
+  implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/fk-joins/kstreams/code/build.gradle
+++ b/_includes/tutorials/fk-joins/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/fk-joins/kstreams/code/build.gradle
+++ b/_includes/tutorials/fk-joins/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "org.apache.kafka:kafka-streams:3.4.0"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
@@ -31,6 +31,11 @@ dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'

--- a/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
-  implementation 'org.apache.kafka:kafka-streams:3.3.1'
+  implementation 'org.apache.kafka:kafka-streams:3.4.0'
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
-  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'
+  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/joining-stream-table/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'

--- a/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-consumer-application/kafka/code/build.gradle
@@ -30,7 +30,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-clients:3.3.1"
+    implementation "org.apache.kafka:kafka-clients:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
@@ -31,11 +31,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
@@ -30,7 +30,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application-callback/kafka/code/build.gradle
@@ -30,8 +30,8 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
+++ b/_includes/tutorials/kafka-producer-application/kafka/code/build.gradle
@@ -30,8 +30,8 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-clients:3.3.1"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    implementation "org.apache.kafka:kafka-clients:3.4.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/merging/kstreams/code/build.gradle
+++ b/_includes/tutorials/merging/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/merging/kstreams/code/build.gradle
+++ b/_includes/tutorials/merging/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/merging/kstreams/code/build.gradle
+++ b/_includes/tutorials/merging/kstreams/code/build.gradle
@@ -30,7 +30,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/message-ordering/kafka/code/build.gradle
+++ b/_includes/tutorials/message-ordering/kafka/code/build.gradle
@@ -30,11 +30,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/message-ordering/kafka/code/build.gradle
+++ b/_includes/tutorials/message-ordering/kafka/code/build.gradle
@@ -29,7 +29,7 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/message-ordering/kafka/code/build.gradle
+++ b/_includes/tutorials/message-ordering/kafka/code/build.gradle
@@ -29,7 +29,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
+++ b/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
@@ -48,7 +48,12 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.22.2'
     implementation 'org.apache.avro:avro:1.11.1'
     implementation 'org.slf4j:slf4j-simple:2.0.7'
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
     implementation "io.confluent:kafka-avro-serializer:7.1.4"

--- a/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
+++ b/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
@@ -49,11 +49,11 @@ dependencies {
     implementation 'org.apache.avro:avro:1.11.1'
     implementation 'org.slf4j:slf4j-simple:2.0.7'
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
     implementation "io.confluent:kafka-avro-serializer:7.1.4"

--- a/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
+++ b/_includes/tutorials/multiple-event-types/kafka/code/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.22.2'
     implementation 'org.apache.avro:avro:1.11.1'
     implementation 'org.slf4j:slf4j-simple:2.0.7'
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
     implementation "io.confluent:kafka-avro-serializer:7.1.4"

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -34,11 +34,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -33,9 +33,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/build.gradle
@@ -33,7 +33,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/src/main/java/io/confluent/developer/NamingChangelogAndRepartitionTopics.java
+++ b/_includes/tutorials/naming-changelog-repartition-topics/kstreams/code/src/main/java/io/confluent/developer/NamingChangelogAndRepartitionTopics.java
@@ -38,7 +38,7 @@ public class NamingChangelogAndRepartitionTopics {
     props.put(StreamsConfig.APPLICATION_ID_CONFIG, envProps.getProperty("application.id"));
     props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, envProps.getProperty("bootstrap.servers"));
     props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
-    props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    props.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
 
     return props;
   }

--- a/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/src/main/java/io/confluent/developer/KafkaStreamsKTableTTLExample.java
+++ b/_includes/tutorials/schedule-ktable-ttl-aggregate/kstreams/code/src/main/java/io/confluent/developer/KafkaStreamsKTableTTLExample.java
@@ -140,7 +140,7 @@ public class KafkaStreamsKTableTTLExample {
 
     // These two settings are only required in this contrived example so that the
     // streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 0);
-    // streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    // streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
     return envProps;
   }
 

--- a/_includes/tutorials/schedule-ktable-ttl/kstreams/code/src/main/java/io/confluent/developer/KafkaStreamsKTableTTLExample.java
+++ b/_includes/tutorials/schedule-ktable-ttl/kstreams/code/src/main/java/io/confluent/developer/KafkaStreamsKTableTTLExample.java
@@ -120,7 +120,7 @@ public class KafkaStreamsKTableTTLExample {
     
     // These two settings are only required in this contrived example so that the 
     // streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 0);
-    // streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    // streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
     return streamsConfiguration;
   }
 
@@ -159,7 +159,7 @@ public class KafkaStreamsKTableTTLExample {
     
     // These two settings are only required in this contrived example so that the 
     // streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 0);
-    // streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    // streamsConfiguration.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
     return envProps;
   }
 

--- a/_includes/tutorials/serialization/kstreams/code/build.gradle
+++ b/_includes/tutorials/serialization/kstreams/code/build.gradle
@@ -35,12 +35,12 @@ dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "com.google.protobuf:protobuf-java:3.22.2"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "org.apache.kafka:kafka-streams:3.4.0"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation "io.confluent:kafka-streams-protobuf-serde:7.3.0"
   implementation 'com.google.code.gson:gson:2.10.1'
 
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/_includes/tutorials/serialization/kstreams/code/build.gradle
+++ b/_includes/tutorials/serialization/kstreams/code/build.gradle
@@ -35,12 +35,12 @@ dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "com.google.protobuf:protobuf-java:3.22.2"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.4.0"
+  implementation "org.apache.kafka:kafka-streams:3.3.0"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   implementation "io.confluent:kafka-streams-protobuf-serde:7.3.0"
   implementation 'com.google.code.gson:gson:2.10.1'
 
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.0"
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/_includes/tutorials/serialization/kstreams/code/src/test/java/io/confluent/developer/serialization/SerializationTutorialTest.java
+++ b/_includes/tutorials/serialization/kstreams/code/src/test/java/io/confluent/developer/serialization/SerializationTutorialTest.java
@@ -33,8 +33,9 @@ public class SerializationTutorialTest {
 
     final SpecificAvroSerde<Movie> avroSerde = tutorial.movieAvroSerde(envProps);
     final KafkaProtobufSerde<MovieProtos.Movie> protobufSerde = tutorial.movieProtobufSerde(envProps);
-
+    
     Topology topology = tutorial.buildTopology(envProps, avroSerde, protobufSerde);
+    streamsProps.put("statestore.cache.max.bytes", 0);
     TopologyTestDriver testDriver = new TopologyTestDriver(topology, streamsProps);
 
     testDriver

--- a/_includes/tutorials/session-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/session-windows/kstreams/code/build.gradle
@@ -32,11 +32,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"

--- a/_includes/tutorials/session-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/session-windows/kstreams/code/build.gradle
@@ -31,10 +31,10 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/session-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/session-windows/kstreams/code/build.gradle
@@ -31,7 +31,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     implementation "org.apache.kafka:kafka-clients:3.1.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"

--- a/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
@@ -33,11 +33,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation('io.confluent:kafka-streams-avro-serde:7.3.0')
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
@@ -32,7 +32,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation('io.confluent:kafka-streams-avro-serde:7.3.0')
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/sliding-windows/kstreams/code/build.gradle
@@ -32,9 +32,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation('io.confluent:kafka-streams-avro-serde:7.3.0')
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/splitting/kstreams/code/build.gradle
+++ b/_includes/tutorials/splitting/kstreams/code/build.gradle
@@ -31,7 +31,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.4.0"
+  implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/splitting/kstreams/code/build.gradle
+++ b/_includes/tutorials/splitting/kstreams/code/build.gradle
@@ -32,11 +32,11 @@ dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
   testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"

--- a/_includes/tutorials/splitting/kstreams/code/build.gradle
+++ b/_includes/tutorials/splitting/kstreams/code/build.gradle
@@ -31,9 +31,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
   implementation "org.apache.avro:avro:1.11.1"
   implementation "org.slf4j:slf4j-simple:2.0.7"
-  implementation "org.apache.kafka:kafka-streams:3.3.1"
+  implementation "org.apache.kafka:kafka-streams:3.4.0"
   implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+  testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
   testImplementation "junit:junit:4.13.2"
 }
 

--- a/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
@@ -30,7 +30,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
+++ b/_includes/tutorials/streams-to-table/kstreams/code/build.gradle
@@ -30,8 +30,8 @@ apply plugin: "com.github.johnrengelman.shadow"
 
 dependencies {
     implementation "org.slf4j:slf4j-simple:2.0.7"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/time-concepts/ksql/code/build.gradle
+++ b/_includes/tutorials/time-concepts/ksql/code/build.gradle
@@ -32,9 +32,9 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.0"
     implementation "org.slf4j:slf4j-simple:1.7.30"
-    implementation "org.apache.kafka:kafka-streams:3.3.1"
+    implementation "org.apache.kafka:kafka-streams:3.4.0"
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.3.1"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.1"
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/_includes/tutorials/time-concepts/ksql/code/build.gradle
+++ b/_includes/tutorials/time-concepts/ksql/code/build.gradle
@@ -33,11 +33,11 @@ dependencies {
     implementation "org.apache.avro:avro:1.11.0"
     implementation "org.slf4j:slf4j-simple:1.7.30"
     implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.1"

--- a/_includes/tutorials/time-concepts/ksql/code/build.gradle
+++ b/_includes/tutorials/time-concepts/ksql/code/build.gradle
@@ -32,7 +32,12 @@ apply plugin: "com.github.johnrengelman.shadow"
 dependencies {
     implementation "org.apache.avro:avro:1.11.0"
     implementation "org.slf4j:slf4j-simple:1.7.30"
-    implementation "org.apache.kafka:kafka-streams:3.4.0"
+    implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
     implementation "io.confluent:kafka-streams-avro-serde:7.3.0"
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "junit:junit:4.13.1"

--- a/_includes/tutorials/transforming/kstreams/code/build.gradle
+++ b/_includes/tutorials/transforming/kstreams/code/build.gradle
@@ -31,6 +31,11 @@ dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'

--- a/_includes/tutorials/transforming/kstreams/code/build.gradle
+++ b/_includes/tutorials/transforming/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
-  implementation 'org.apache.kafka:kafka-streams:3.3.1'
+  implementation 'org.apache.kafka:kafka-streams:3.4.0'
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
-  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'
+  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/_includes/tutorials/transforming/kstreams/code/build.gradle
+++ b/_includes/tutorials/transforming/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'

--- a/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
@@ -31,6 +31,11 @@ dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
+implementation ('org.apache.kafka:kafka-clients') {
+    version {
+        strictly '3.4.0'
+    }
+  }
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'

--- a/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
@@ -30,9 +30,9 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
-  implementation 'org.apache.kafka:kafka-streams:3.3.1'
+  implementation 'org.apache.kafka:kafka-streams:3.4.0'
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
-  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.3.1'
+  testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'
 }
 

--- a/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/build.gradle
@@ -31,11 +31,11 @@ dependencies {
   implementation 'org.apache.avro:avro:1.11.1'
   implementation 'org.slf4j:slf4j-simple:2.0.7'
   implementation 'org.apache.kafka:kafka-streams:3.4.0'
-implementation ('org.apache.kafka:kafka-clients') {
-    version {
-        strictly '3.4.0'
-    }
-  }
+    implementation ('org.apache.kafka:kafka-clients') {
+       version {
+           strictly '3.4.0'
+        }
+      }
   implementation 'io.confluent:kafka-streams-avro-serde:7.3.0'
   testImplementation 'org.apache.kafka:kafka-streams-test-utils:3.4.0'
   testImplementation 'junit:junit:4.13.2'

--- a/_includes/tutorials/tumbling-windows/kstreams/code/src/main/java/io/confluent/developer/TumblingWindow.java
+++ b/_includes/tutorials/tumbling-windows/kstreams/code/src/main/java/io/confluent/developer/TumblingWindow.java
@@ -37,7 +37,7 @@ public class TumblingWindow {
         allProps.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         allProps.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, SpecificAvroSerde.class);
         allProps.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, RatingTimestampExtractor.class.getName());
-        allProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        allProps.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         try {
             allProps.put(StreamsConfig.STATE_DIR_CONFIG,
                       Files.createTempDirectory("tumbling-windows").toAbsolutePath().toString());

--- a/_includes/tutorials/window-final-result/kstreams/code/build.gradle
+++ b/_includes/tutorials/window-final-result/kstreams/code/build.gradle
@@ -44,11 +44,11 @@ dependencies {
     implementation group: 'com.typesafe', name: 'config', version: '1.4.2'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.11'
 
-    implementation group: 'org.apache.kafka', name: 'kafka-streams', version: '3.1.0'
-    implementation group: 'io.confluent', name: 'kafka-streams-avro-serde', version: '7.1.0'
+    implementation group: 'org.apache.kafka', name: 'kafka-streams', version: '3.4.0'
+    implementation group: 'io.confluent', name: 'kafka-streams-avro-serde', version: '7.3.1'
 
     testImplementation "junit:junit:4.13.2"
-    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.1.0"
+    testImplementation "org.apache.kafka:kafka-streams-test-utils:3.4.0"
     testImplementation "com.github.grantwest.eventually:hamcrest-eventually-matchers:0.0.3"
 
     // helpers

--- a/_includes/tutorials/window-final-result/kstreams/code/src/main/java/io/confluent/developer/WindowFinalResult.java
+++ b/_includes/tutorials/window-final-result/kstreams/code/src/main/java/io/confluent/developer/WindowFinalResult.java
@@ -36,7 +36,7 @@ public class WindowFinalResult {
         properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, StringSerde.class);
         properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, StringSerde.class);
         properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-        properties.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        properties.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
 
         return properties;
     }


### PR DESCRIPTION
### Description

Part one of two PRs for this [asana](https://app.asana.com/0/1201906632362444/1203406237816996/f) ticket
This PR expanded to cover a little more ground than anticipated.  The reasons for the expanded scope are:

1.  The `3.4.0` version of Kafka Streams deprecated the `CACHE_MAX_BYTES_BUFFERING_CONFIG` in favor of `STATESTORE_CACHE_MAX_BYTES_CONFIG`.  So those configurations needed to be updated
2.  Several Kafka Streams tutorials failed because the application uses a new method available in Kafka-Clients `3.4.0`, but there's a transitive clients dependency pulled in by tutorials using Schema Registry serdes.  Instead of relying on implicit dependencies, I decided that any Kafka Streams tutorial should explicitly declare the required version of Kafka-Clients needed in the `build.gradle` file.   We can update AK dependencies independent of the CP releases by making this change.

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
