### PR TITLE
Minor: add ksqldb-latest to allow-list for semaphore

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -11,3 +11,4 @@ semaphore:
   branches:
   - master
   - release
+  - ksqldb-latest


### PR DESCRIPTION
### Description

ksql team previously used the `ksqldb-latest` branch in this repo as part of ksql release validation, but builds of this branch of not currently triggered due to the branch not being in the allow-list for semaphore (ever since the migration to managing this repo by service bot). This PR adds the branch to the whitelist. ksql team will update the `ksqldb-latest` branch whenever a new ksql RC is generated (roughly nightly) in order to automatically validate the RC against the ksqldb tutorials in kafka-tutorials.

The `ksqldb-latest` branch is out of date with `master`, so it may take some time to get the builds passing again. Enabling builds again is the first step.

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
