### PR TITLE
Fix spelling error steams -> streams

### DIFF
--- a/_includes/tutorials/udf/ksql/markup/dev/make-build-file.adoc
+++ b/_includes/tutorials/udf/ksql/markup/dev/make-build-file.adoc
@@ -4,4 +4,4 @@ Create the following Gradle build file, named `build.gradle` for the project:
 <pre class="snippet"><code class="groovy">{% include_raw tutorials/udf/ksql/code/build.gradle %}</code></pre>
 +++++
 
-The `build.gradle` also contains a `copyJar` step to copy the jar file to the `extensions/` directory where it will be picked up by KSQL. This is convenient when you are iterating on a function. For example, you might have tested your UDF against your suite of unit tests and you are now ready to test against steams in KSQL. With the jar in the correct place, a restart of KSQL will load your updated jar.
+The `build.gradle` also contains a `copyJar` step to copy the jar file to the `extensions/` directory where it will be picked up by KSQL. This is convenient when you are iterating on a function. For example, you might have tested your UDF against your suite of unit tests and you are now ready to test against streams in KSQL. With the jar in the correct place, a restart of KSQL will load your updated jar.


### PR DESCRIPTION
### Description

For [asana](https://app.asana.com/0/1201906632362444/1204595026954264/f)

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
