### PR TITLE
fix broken links due to template backslash

### DIFF
--- a/_includes/shared/markup/ccloud/provision-cluster.adoc
+++ b/_includes/shared/markup/ccloud/provision-cluster.adoc
@@ -1,1 +1,1 @@
-Provision a Kafka cluster in link:https://www.confluent.io/confluent-cloud/tryfree/\?next=tutorials/ksql-recipe-{{ page.static_data }}[Confluent Cloud].
+Provision a Kafka cluster in link:https://www.confluent.io/confluent-cloud/tryfree/?next=tutorials/ksql-recipe-{{ page.static_data }}[Confluent Cloud].


### PR DESCRIPTION
### Description
Link `Confluent Cloud` is broken on browsers that do not convert `\` to `/`

<img width="313" alt="image" src="https://github.com/confluentinc/kafka-tutorials/assets/22008030/e77ba26b-296f-492d-825f-b0e6ef52ddbd">

Example of broken link: `https://www.confluent.io/confluent-cloud/tryfree/\?next=tutorials/ksql-recipe-audit-logs`
expected link: `https://www.confluent.io/confluent-cloud/tryfree/?next=tutorials/ksql-recipe-audit-logs`

Example of broken link: https://developer.confluent.io/tutorials/dynamic-pricing/confluent.html#:~:text=Kafka%20cluster%20in-,Confluent%20Cloud.,-Once%20your%20Confluent

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/rafikalid/fix-backslash-broken-link/denormalization/confluent.html

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
