### PR TITLE
update Confluent CLI install instructions to point to docs rather than in product instructions

### DIFF
--- a/_includes/shared/markup/ccloud/get-ccloud.adoc
+++ b/_includes/shared/markup/ccloud/get-ccloud.adoc
@@ -1,3 +1,1 @@
-This tutorial has some steps for Kafka topic management and/or reading from or writing to Kafka topics, for which you can use the Confluent Cloud Console or install the Confluent CLI.
-Instructions for installing Confluent CLI and configuring it to your Confluent Cloud environment is available from within the Confluent Cloud Console: navigate to your Kafka cluster, click on the `CLI and tools` link, and run through the steps in the `Confluent CLI` tab.
-
+This tutorial has some steps for Kafka topic management and producing and consuming events, for which you can use the Confluent Cloud Console or the Confluent CLI. Follow the instructions https://docs.confluent.io/confluent-cli/current/install.html[here] to install the Confluent CLI, and then follow https://docs.confluent.io/confluent-cli/current/connect.html[these steps] connect the CLI to your Confluent Cloud cluster.


### PR DESCRIPTION
The documentation is more up to date (e.g., brew install) and the in-product steps are hard to find.

### Description

[asana](https://app.asana.com/0/1201906632362444/1204828909163520/f)

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/update-cli-install-steps/