### PR TITLE
Nit: Fix format for `confluent kafka topic consume`

### DIFF
--- a/_includes/tutorials/aggregating-count/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
+++ b/_includes/tutorials/aggregating-count/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
@@ -1,5 +1,4 @@
 confluent kafka topic produce movie-ticket-sales \
   --parse-key \
-  --delimiter ":" \
   --value-format avro \
   --schema src/main/avro/ticket-sale.avsc

--- a/_includes/tutorials/aggregating-sum/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
+++ b/_includes/tutorials/aggregating-sum/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
@@ -1,5 +1,4 @@
 confluent kafka topic produce movie-ticket-sales \
   --parse-key \
-  --delimiter ":" \
   --value-format avro \
   --schema src/main/avro/ticket-sale.avsc

--- a/_includes/tutorials/cogrouping-streams/confluent/code/tutorial-steps/dev/ccloud-produce-one.sh
+++ b/_includes/tutorials/cogrouping-streams/confluent/code/tutorial-steps/dev/ccloud-produce-one.sh
@@ -1,5 +1,4 @@
 confluent kafka topic produce app-one-topic \
        --parse-key \
-       --delimiter ":" \
        --value-format avro \
        --schema src/main/avro/login-event.avsc

--- a/_includes/tutorials/cogrouping-streams/confluent/code/tutorial-steps/dev/ccloud-produce-three.sh
+++ b/_includes/tutorials/cogrouping-streams/confluent/code/tutorial-steps/dev/ccloud-produce-three.sh
@@ -1,5 +1,4 @@
 confluent kafka topic produce app-three-topic \
        --parse-key \
-       --delimiter ":" \
        --value-format avro \
        --schema src/main/avro/login-event.avsc

--- a/_includes/tutorials/cogrouping-streams/confluent/code/tutorial-steps/dev/ccloud-produce-two.sh
+++ b/_includes/tutorials/cogrouping-streams/confluent/code/tutorial-steps/dev/ccloud-produce-two.sh
@@ -1,5 +1,4 @@
 confluent kafka topic produce app-two-topic \
        --parse-key \
-       --delimiter ":" \
        --value-format avro \
        --schema src/main/avro/login-event.avsc

--- a/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,7 +1,7 @@
 Using a terminal window, run the following command to start a Confluent CLI producer:
 
 ```
-confluent kafka topic produce parallel-consumer-input-topic --parse-key --delimiter ":"
+confluent kafka topic produce parallel-consumer-input-topic --parse-key
 ```
 
 Each line represents input data for the Confluent Parallel Consumer application. To send all of the events below, paste the following into the prompt and press enter:

--- a/_includes/tutorials/console-consumer-producer-avro/confluent/code/tutorial-steps/dev/console-producer-keys.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/confluent/code/tutorial-steps/dev/console-producer-keys.sh
@@ -1,1 +1,1 @@
-confluent kafka topic produce orders-avro --value-format avro --schema orders-avro-schema.json --parse-key --delimiter ":"
+confluent kafka topic produce orders-avro --value-format avro --schema orders-avro-schema.json --parse-key

--- a/_includes/tutorials/console-consumer-producer-avro/confluent/code/tutorial-steps/dev/harness-console-consumer-keys.sh
+++ b/_includes/tutorials/console-consumer-producer-avro/confluent/code/tutorial-steps/dev/harness-console-consumer-keys.sh
@@ -1,1 +1,1 @@
-confluent kafka topic consume orders-avro --value-format avro --print-key --delimiter "-"  --from-beginning
+confluent kafka topic consume orders-avro --value-format avro --print-key --delimiter "-" --from-beginning

--- a/_includes/tutorials/console-consumer-producer-basic/confluent/code/tutorial-steps/dev/console-producer-keys.sh
+++ b/_includes/tutorials/console-consumer-producer-basic/confluent/code/tutorial-steps/dev/console-producer-keys.sh
@@ -1,1 +1,1 @@
-confluent kafka topic produce orders --parse-key --delimiter ":"
+confluent kafka topic produce orders --parse-key

--- a/_includes/tutorials/console-consumer-read-specific-offsets-partition/confluent/code/tutorial-steps/dev/console-producer-keys.sh
+++ b/_includes/tutorials/console-consumer-read-specific-offsets-partition/confluent/code/tutorial-steps/dev/console-producer-keys.sh
@@ -1,1 +1,1 @@
-confluent kafka topic produce example-topic --parse-key --delimiter ":"
+confluent kafka topic produce example-topic --parse-key

--- a/_includes/tutorials/dynamic-output-topic/confluent/code/tutorial-steps/dev/ccloud-producer.sh
+++ b/_includes/tutorials/dynamic-output-topic/confluent/code/tutorial-steps/dev/ccloud-producer.sh
@@ -1,5 +1,4 @@
 confluent kafka topic produce input \
   --parse-key \
-  --delimiter ":" \
   --value-format avro \
   --schema src/main/avro/order.avsc

--- a/_includes/tutorials/filtering/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
+++ b/_includes/tutorials/filtering/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
@@ -1,5 +1,4 @@
 confluent kafka topic produce publications \
   --parse-key \
-  --delimiter ":" \
   --value-format avro \
   --schema src/main/avro/publication.avsc

--- a/_includes/tutorials/finding-distinct/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
+++ b/_includes/tutorials/finding-distinct/confluent/code/tutorial-steps/dev/ccloud-produce-events.sh
@@ -1,5 +1,4 @@
 confluent kafka topic produce clicks \
   --parse-key \
-  --delimiter ":" \
   --value-format avro \
   --schema src/main/avro/click.avsc

--- a/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/run-consumer.adoc
@@ -1,7 +1,7 @@
 Now run a console consumer that will read topics from the output topic to confirm your application published the expected records.
 
 ```bash
-confluent kafka topic consume output-topic --from-beginning --print-key --delimiter " : "
+confluent kafka topic consume output-topic --print-key --delimiter " : " --from-beginning
 ```
 
 The output from the consumer can vary if you added any of your own records, but it should look something like this:

--- a/_includes/tutorials/kafka-producer-application/confluent/code/tutorial-steps/dev/ccloud-cli-consumer.sh
+++ b/_includes/tutorials/kafka-producer-application/confluent/code/tutorial-steps/dev/ccloud-cli-consumer.sh
@@ -1,1 +1,1 @@
-confluent kafka topic consume output-topic -b --print-key --delimiter " : "
+confluent kafka topic consume output-topic --print-key --delimiter " : " --from-beginning

--- a/_includes/tutorials/streams-to-table/confluent/code/tutorial-steps/dev/console-producer.sh
+++ b/_includes/tutorials/streams-to-table/confluent/code/tutorial-steps/dev/console-producer.sh
@@ -1,1 +1,1 @@
-confluent kafka topic produce input-topic --parse-key --delimiter ":"
+confluent kafka topic produce input-topic --parse-key

--- a/_includes/tutorials/streams-to-table/confluent/code/tutorial-steps/dev/streams-console-consumer.sh
+++ b/_includes/tutorials/streams-to-table/confluent/code/tutorial-steps/dev/streams-console-consumer.sh
@@ -1,1 +1,1 @@
-confluent kafka topic consume streams-output-topic -b --print-key --delimiter " - "
+confluent kafka topic consume streams-output-topic --print-key --delimiter " - " --from-beginning

--- a/_includes/tutorials/streams-to-table/confluent/code/tutorial-steps/dev/table-console-consumer.sh
+++ b/_includes/tutorials/streams-to-table/confluent/code/tutorial-steps/dev/table-console-consumer.sh
@@ -1,1 +1,1 @@
-confluent kafka topic consume table-output-topic -b --print-key --delimiter " - "
+confluent kafka topic consume table-output-topic --print-key --delimiter " - " --from-beginning


### PR DESCRIPTION
### Description
Standardize format for produce/consume commands in examples