### PR TITLE
add a second new line so cat func doesn't mess up config

### DIFF
--- a/_includes/tutorials/creating-first-apache-kafka-streams-application/confluent/code/configuration/dev.properties
+++ b/_includes/tutorials/creating-first-apache-kafka-streams-application/confluent/code/configuration/dev.properties
@@ -5,3 +5,4 @@ output.topic.name=tall-random-strings
 
 key.serializer=org.apache.kafka.common.serialization.StringSerializer
 value.serializer=org.apache.kafka.common.serialization.StringSerializer
+


### PR DESCRIPTION
### Description

no issue, but needed to add a newline to this piece of config, otherwise the cat command in the tutorial messes up the config

### Staging Docs

no docs stages

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
