### PR TITLE
Don't format confluent commands as Bash

### DIFF
--- a/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,6 +1,6 @@
 Run the following command to start a Confluent CLI consumer to view consume the events that have been filtered by your application:
 
-```
+```plaintext
 confluent kafka topic consume movie-tickets-sold -b --print-key
 ```
 

--- a/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/aggregating-count/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,6 +1,6 @@
 Run the following command to start a Confluent CLI consumer to view consume the events that have been filtered by your application:
 
-```bash
+```
 confluent kafka topic consume movie-tickets-sold -b --print-key
 ```
 

--- a/_includes/tutorials/aggregating-sum/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/aggregating-sum/confluent/markup/dev/run-consumer.adoc
@@ -1,7 +1,7 @@
 Leaving your original terminal running, open another to consume the events that have been filtered by your application:
 
-```bash
-confluent kafka topic consume movie-revenue -b --print-key
+```
+confluent kafka topic consume movie-revenue --from-beginning --print-key
 ```
 
 After the consumer starts, you should see the following messages. Note that for every key (movie), a sequence of output records (sum) is emitted. Each record represents an update to the sum, which is sent on every movie event specifically because caching is disabled in the code with `StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG` set to `0`. Read more on `https://docs.confluent.io/current/streams/developer-guide/memory-mgmt.html#record-caches-in-the-dsl[Record caches in the DSL]`.

--- a/_includes/tutorials/aggregating-sum/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/aggregating-sum/confluent/markup/dev/run-consumer.adoc
@@ -1,6 +1,6 @@
 Leaving your original terminal running, open another to consume the events that have been filtered by your application:
 
-```
+```plaintext
 confluent kafka topic consume movie-revenue --from-beginning --print-key
 ```
 

--- a/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,6 +1,6 @@
 Using a terminal window, run the following command to start a Confluent CLI producer:
 
-```
+```plaintext
 confluent kafka topic produce parallel-consumer-input-topic --parse-key
 ```
 

--- a/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/dev/make-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```bash
+```
 confluent kafka topic create parallel-consumer-input-topic
 ```

--- a/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/dev/make-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```
+```plaintext
 confluent kafka topic create parallel-consumer-input-topic
 ```

--- a/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/perftest/make-topic.adoc
+++ b/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/perftest/make-topic.adoc
@@ -1,5 +1,5 @@
 Use the following command to create a topic that we'll use for performance testing:
 
-```bash
+```
 confluent kafka topic create perftest-parallel-consumer-input-topic
 ```

--- a/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/perftest/make-topic.adoc
+++ b/_includes/tutorials/confluent-parallel-consumer-application/confluent/markup/perftest/make-topic.adoc
@@ -1,5 +1,5 @@
 Use the following command to create a topic that we'll use for performance testing:
 
-```
+```plaintext
 confluent kafka topic create perftest-parallel-consumer-input-topic
 ```

--- a/_includes/tutorials/count-messages/confluent/markup/dev/create-topic.adoc
+++ b/_includes/tutorials/count-messages/confluent/markup/dev/create-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```
+```plaintext
 confluent kafka topic create test-topic
 ```     

--- a/_includes/tutorials/count-messages/confluent/markup/dev/create-topic.adoc
+++ b/_includes/tutorials/count-messages/confluent/markup/dev/create-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```bash
+```
 confluent kafka topic create test-topic
 ```     

--- a/_includes/tutorials/error-handling/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/error-handling/confluent/markup/dev/run-consumer.adoc
@@ -8,7 +8,7 @@ Now that you've run the Kafka Streams application, it should have shut itself do
 
 Let's now run the Confluent CLI to confirm the output:
 
-```
+```plaintext
 confluent kafka topic consume output-topic --from-beginning
 ```
 

--- a/_includes/tutorials/error-handling/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/error-handling/confluent/markup/dev/run-consumer.adoc
@@ -8,7 +8,7 @@ Now that you've run the Kafka Streams application, it should have shut itself do
 
 Let's now run the Confluent CLI to confirm the output:
 
-```bash
+```
 confluent kafka topic consume output-topic --from-beginning
 ```
 

--- a/_includes/tutorials/filtering/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/filtering/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,6 +1,6 @@
 Run the following command to start a Confluent CLI consumer to view the distinct click events:
 
-```
+```plaintext
 confluent kafka topic consume filtered-publications --from-beginning --value-format avro
 ```
 

--- a/_includes/tutorials/filtering/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/filtering/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,7 +1,7 @@
 Run the following command to start a Confluent CLI consumer to view the distinct click events:
 
-```bash
-confluent kafka topic consume filtered-publications -b --value-format avro
+```
+confluent kafka topic consume filtered-publications --from-beginning --value-format avro
 ```
 
 Depending on the cadence and values you produce in the steps above, you should see messages similar to the following:

--- a/_includes/tutorials/finding-distinct/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/finding-distinct/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,6 +1,6 @@
 Run the following command to start a Confluent CLI consumer to view the distinct click events:
 
-```bash
+```
 confluent kafka topic consume distinct-clicks -b --value-format avro
 ```
 

--- a/_includes/tutorials/finding-distinct/confluent/markup/dev/ccloud-run-consume.adoc
+++ b/_includes/tutorials/finding-distinct/confluent/markup/dev/ccloud-run-consume.adoc
@@ -1,6 +1,6 @@
 Run the following command to start a Confluent CLI consumer to view the distinct click events:
 
-```
+```plaintext
 confluent kafka topic consume distinct-clicks -b --value-format avro
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-consume-rated-movies.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-consume-rated-movies.adoc
@@ -1,6 +1,6 @@
 Before you start producing ratings, it's a good idea to set up the consumer on the output topic. This way, as soon as you produce ratings (and they're joined to movies), you'll see the results right away. Run this to get ready to consume the rated movies:
 
-```
+```plaintext
 confluent kafka topic consume rated-movies --from-beginning --value-format avro
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-consume-rated-movies.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-consume-rated-movies.adoc
@@ -1,6 +1,6 @@
 Before you start producing ratings, it's a good idea to set up the consumer on the output topic. This way, as soon as you produce ratings (and they're joined to movies), you'll see the results right away. Run this to get ready to consume the rated movies:
 
-```bash
+```
 confluent kafka topic consume rated-movies --from-beginning --value-format avro
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-movies.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-movies.adoc
@@ -1,6 +1,6 @@
 In a new terminal, run:
 
-```
+```plaintext
 confluent kafka topic produce movies --value-format avro --schema src/main/avro/movie.avsc
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-movies.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-movies.adoc
@@ -1,6 +1,6 @@
 In a new terminal, run:
 
-```bash
+```
 confluent kafka topic produce movies --value-format avro --schema src/main/avro/movie.avsc
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-ratings.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-ratings.adoc
@@ -1,6 +1,6 @@
 Run the following in a new terminal window. This process is the most fun if you can see this and the previous terminal (which is consuming the rated movies) at the same time. If your terminal program lets you do horizontal split panes, try it that way:
 
-```bash
+```
 confluent kafka topic produce ratings --value-format avro --schema src/main/avro/rating.avsc
 ```
 

--- a/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-ratings.adoc
+++ b/_includes/tutorials/joining-stream-table/confluent/markup/dev/ccloud-produce-ratings.adoc
@@ -1,6 +1,6 @@
 Run the following in a new terminal window. This process is the most fun if you can see this and the previous terminal (which is consuming the rated movies) at the same time. If your terminal program lets you do horizontal split panes, try it that way:
 
-```
+```plaintext
 confluent kafka topic produce ratings --value-format avro --schema src/main/avro/rating.avsc
 ```
 

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,6 +1,6 @@
 Using a terminal window, run the following command to start a Confluent CLI producer:
 
-```bash
+```
 confluent kafka topic produce input-topic
 ```
 

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,6 +1,6 @@
 Using a terminal window, run the following command to start a Confluent CLI producer:
 
-```
+```plaintext
 confluent kafka topic produce input-topic
 ```
 

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```bash
+```
 confluent kafka topic create input-topic
 ```

--- a/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/kafka-consumer-application/confluent/markup/dev/make-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```
+```plaintext
 confluent kafka topic create input-topic
 ```

--- a/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/create-topic.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/create-topic.adoc
@@ -4,7 +4,7 @@ In this step we're going to create a topic for use during this tutorial.
 
 Open a new terminal window and then run this command to create the topic that the producer can write to
 
-```
+```plaintext
 confluent kafka topic create output-topic
 ```
 

--- a/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/create-topic.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/create-topic.adoc
@@ -4,7 +4,7 @@ In this step we're going to create a topic for use during this tutorial.
 
 Open a new terminal window and then run this command to create the topic that the producer can write to
 
-```bash
+```
 confluent kafka topic create output-topic
 ```
 

--- a/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/run-consumer.adoc
@@ -1,6 +1,6 @@
 Now run a console consumer that will read topics from the output topic to confirm your application published the expected records.
 
-```
+```plaintext
 confluent kafka topic consume output-topic --print-key --delimiter " : " --from-beginning
 ```
 

--- a/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/kafka-producer-application-callback/confluent/markup/dev/run-consumer.adoc
@@ -1,6 +1,6 @@
 Now run a console consumer that will read topics from the output topic to confirm your application published the expected records.
 
-```bash
+```
 confluent kafka topic consume output-topic --print-key --delimiter " : " --from-beginning
 ```
 

--- a/_includes/tutorials/kafka-producer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/kafka-producer-application/confluent/markup/dev/make-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```bash
+```
 confluent kafka topic create output-topic --partitions 1
 ```

--- a/_includes/tutorials/kafka-producer-application/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/kafka-producer-application/confluent/markup/dev/make-topic.adoc
@@ -1,5 +1,5 @@
 In this step we’re going to create a topic for use during this tutorial. Use the following command to create the topic:
 
-```
+```plaintext
 confluent kafka topic create output-topic --partitions 1
 ```

--- a/_includes/tutorials/merging/confluent/markup/dev/run-classical-producer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-classical-producer.adoc
@@ -1,6 +1,6 @@
 To produce the classical songs, open up another terminal and run:
 
-```
+```plaintext
 confluent kafka topic produce classical-song-events \
     --value-format avro \
     --schema src/main/avro/song_event.avsc

--- a/_includes/tutorials/merging/confluent/markup/dev/run-classical-producer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-classical-producer.adoc
@@ -1,6 +1,6 @@
 To produce the classical songs, open up another terminal and run:
 
-```bash
+```
 confluent kafka topic produce classical-song-events \
     --value-format avro \
     --schema src/main/avro/song_event.avsc

--- a/_includes/tutorials/merging/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-consumer.adoc
@@ -1,6 +1,6 @@
 Leaving your original terminals running, open another to consume the events that have been merged:
 
-```
+```plaintext
 confluent kafka topic consume all-song-events \
       --from-beginning \
       --value-format avro

--- a/_includes/tutorials/merging/confluent/markup/dev/run-consumer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-consumer.adoc
@@ -1,6 +1,6 @@
 Leaving your original terminals running, open another to consume the events that have been merged:
 
-```bash
+```
 confluent kafka topic consume all-song-events \
       --from-beginning \
       --value-format avro

--- a/_includes/tutorials/merging/confluent/markup/dev/run-rock-producer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-rock-producer.adoc
@@ -1,6 +1,6 @@
 To produce the input events to their respective topics, you'll want two terminals running. To send the rock songs to their topic, open up a terminal and run the following:
 
-```
+```plaintext
 confluent kafka topic produce rock-song-events \
       --value-format avro \
       --schema src/main/avro/song_event.avsc

--- a/_includes/tutorials/merging/confluent/markup/dev/run-rock-producer.adoc
+++ b/_includes/tutorials/merging/confluent/markup/dev/run-rock-producer.adoc
@@ -1,6 +1,6 @@
 To produce the input events to their respective topics, you'll want two terminals running. To send the rock songs to their topic, open up a terminal and run the following:
 
-```bash
+```
 confluent kafka topic produce rock-song-events \
       --value-format avro \
       --schema src/main/avro/song_event.avsc

--- a/_includes/tutorials/multiple-event-types/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/multiple-event-types/confluent/markup/dev/make-topic.adoc
@@ -4,7 +4,7 @@ Since you are going to produce records using Protobuf and Avro serialization, yo
 
 Use the following commands to create the topics:
 
-```
+```plaintext
 confluent kafka topic create avro-events
 confluent kafka topic create proto-events
 ```

--- a/_includes/tutorials/multiple-event-types/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/multiple-event-types/confluent/markup/dev/make-topic.adoc
@@ -4,7 +4,7 @@ Since you are going to produce records using Protobuf and Avro serialization, yo
 
 Use the following commands to create the topics:
 
-```bash
+```
 confluent kafka topic create avro-events
 confluent kafka topic create proto-events
 ```

--- a/_includes/tutorials/optimize-producer-throughput/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/optimize-producer-throughput/confluent/markup/dev/make-topic.adoc
@@ -1,7 +1,7 @@
 In this step we’re going to create a topic for use during this tutorial.
 Use the following command to create the topic:
 
-```bash
+```
 confluent kafka topic create topic-perf
 ```
 

--- a/_includes/tutorials/optimize-producer-throughput/confluent/markup/dev/make-topic.adoc
+++ b/_includes/tutorials/optimize-producer-throughput/confluent/markup/dev/make-topic.adoc
@@ -1,7 +1,7 @@
 In this step we’re going to create a topic for use during this tutorial.
 Use the following command to create the topic:
 
-```
+```plaintext
 confluent kafka topic create topic-perf
 ```
 

--- a/_includes/tutorials/session-windows/confluent/markup/dev/ccloud-run-consumer.adoc
+++ b/_includes/tutorials/session-windows/confluent/markup/dev/ccloud-run-consumer.adoc
@@ -1,6 +1,6 @@
 Now that your Kafka Streams application is running, open a new terminal window, change directories (`cd`) into the `session-windows` directory and start a console-consumer to confirm the output:
 
-```bash
+```
 confluent kafka topic consume output-topic --from-beginning --print-key
 ```
 

--- a/_includes/tutorials/session-windows/confluent/markup/dev/ccloud-run-consumer.adoc
+++ b/_includes/tutorials/session-windows/confluent/markup/dev/ccloud-run-consumer.adoc
@@ -1,6 +1,6 @@
 Now that your Kafka Streams application is running, open a new terminal window, change directories (`cd`) into the `session-windows` directory and start a console-consumer to confirm the output:
 
-```
+```plaintext
 confluent kafka topic consume output-topic --from-beginning --print-key
 ```
 

--- a/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-consumer.adoc
+++ b/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-consumer.adoc
@@ -26,8 +26,8 @@ This should yield the following messages:
 
 And finally, to consume all the other genres, run the following:
 
-```
- confluent kafka topic consume other-acting-events --from-beginning --value-format avro
+```plaintext
+confluent kafka topic consume other-acting-events --from-beginning --value-format avro
 ```
 
 This should yield the following messages:

--- a/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-consumer.adoc
+++ b/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-consumer.adoc
@@ -2,7 +2,7 @@ Leave your original terminal running. To consume the output events from each of 
 
 First, to consume the events of drama films, run the following:
 
-```
+```plaintext
 confluent kafka topic consume drama-acting-events --from-beginning --value-format avro
 ```
 
@@ -14,7 +14,7 @@ This should yield the following messages:
 
 Second, to consume those from fantasy films, run the following:
 
-```
+```plaintext
 confluent kafka topic consume fantasy-acting-events --from-beginning --value-format avro
 ```
 

--- a/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-consumer.adoc
+++ b/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-consumer.adoc
@@ -2,7 +2,7 @@ Leave your original terminal running. To consume the output events from each of 
 
 First, to consume the events of drama films, run the following:
 
-```bash
+```
 confluent kafka topic consume drama-acting-events --from-beginning --value-format avro
 ```
 
@@ -14,7 +14,7 @@ This should yield the following messages:
 
 Second, to consume those from fantasy films, run the following:
 
-```bash
+```
 confluent kafka topic consume fantasy-acting-events --from-beginning --value-format avro
 ```
 
@@ -26,7 +26,7 @@ This should yield the following messages:
 
 And finally, to consume all the other genres, run the following:
 
-```bash
+```
  confluent kafka topic consume other-acting-events --from-beginning --value-format avro
 ```
 

--- a/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,6 +1,6 @@
 In a new terminal, run:
 
-```
+```plaintext
 confluent kafka topic produce acting-events --value-format avro --schema src/main/avro/acting_event.avsc
 ```
 

--- a/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-producer.adoc
+++ b/_includes/tutorials/splitting/confluent/markup/dev/ccloud-run-producer.adoc
@@ -1,6 +1,6 @@
 In a new terminal, run:
 
-```bash
+```
 confluent kafka topic produce acting-events --value-format avro --schema src/main/avro/acting_event.avsc
 ```
 


### PR DESCRIPTION
### Description
When CLI commands are formatted as "bash", certain bash-related keywords are highlighted. For example, take a look at step (5) of https://developer.confluent.io/tutorials/how-to-count-messages-on-a-kafka-topic/confluent.html

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->