### PR TITLE
MINOR: Addressing comments from userback

### DIFF
--- a/_data/tutorials.yaml
+++ b/_data/tutorials.yaml
@@ -614,13 +614,13 @@ kafka-producer-application:
     kafka: enabled
     confluent: enabled
 kafka-producer-application-callback:
-  title: How to build an Apache KafkaProducer application with callbacks
+  title: How to build an Apache Kafka &#174; producer application with callbacks
   meta-description: build an Kafka producer application and handle responses using
     the Callback interface
   canonical: confluent
   slug: /kafka-producer-callback-application
-  question: How can you use callbacks with a KafkaProducer to handle produce responses?
-  introduction: You have an application using a Apache KafkaProducer, and you want
+  question: How can you use callbacks with a KafkaProducer to handle responses from the broker?
+  introduction: You have an application using an Apache Kafka producer, and you want
     an automatic way of handling responses after producing records. In this tutorial,
     you'll learn how to use the Callback interface to automatically handle responses
     from producing records.


### PR DESCRIPTION
### Description

[asana 1](https://app.asana.com/0/1201906632362444/1205304367603517/f) and [asana 2](https://app.asana.com/0/1201906632362444/1205304366699157/f)
### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/address_userback_comments/kafka-producer-callback-application/kafka.html

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
