### PR TITLE
Add wait for topic creation

### DIFF
--- a/_data/harnesses/tumbling-windows/flinksql.yml
+++ b/_data/harnesses/tumbling-windows/flinksql.yml
@@ -58,6 +58,12 @@ dev:
           stdout:
             directory: tutorial-steps/dev/outputs
 
+        - name: wait for table execution to complete
+          action: sleep
+          ms: 10000
+          render:
+             skip: true
+
     - title: Validate output
       content:
         - action: execute


### PR DESCRIPTION
### Description

<!-- https://github.com/confluentinc/kafka-tutorials/issues/GH_ISSUE_NUMBER -->

### Staging Docs

<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/ -->
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
