### PR TITLE
chore: Remove extra legalese

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,4 @@
 <footer data-swiftype-index="false" data-tracking-location="footer">
-  <aside class="apache-info">
-    {% include apache.html %}
-  </aside>
   <div class="footer-row">
     <ul class="menu">
       <li><a target="_blank" rel="noopener noreferrer" href="https://www.confluent.io/">Confluent</a></li>
@@ -160,7 +157,7 @@
         Copyright © Confluent, Inc. 2014-<span>2023</span>. Apache, Apache Flink, Apache Kafka, Flink, Kafka, and associated open source
         project names are trademarks of the
         <!-- --> <a target="_blank" rel="noopener noreferrer" href="https://www.apache.org">Apache Software
-          Foundation</a>
+          Foundation</a>.<br/>The Apache Software Foundation has no affiliation with and does not endorse these materials.
       </p>
     </div>
   </div>


### PR DESCRIPTION
### Description

[asana](https://app.asana.com/0/1202927507205730/1205902244329737/f)

### Staging Docs

http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/remove_dueling_legalese/ 
<!-- http://kafka-tutorials-staging.s3-website-us-west-2.amazonaws.com/BRANCH_NAME/KT_PATH -->

### New tutorial checklist

<!-- - [ ] Add a `Short Answer` (if relevant) -->
<!-- - [ ] Implement good test cases (if relevant) -->
<!-- - [ ] Validate hyperlinks -->
<!-- - [ ] Spell check (e.g. using `aspell`) -->
<!-- - [ ] Full code validated in Confluent Cloud -->
<!-- - [ ] SQL style/syntax consistent to existing recipes -->
<!-- - [ ] Validate presentation with `bundle exec jekyll serve --livereload` -->
<!-- - [ ] Tutorial added to appropriate `index.html` or `use-case.html` file -->
<!-- - [ ] Source connector's auto topic naming convention works with the ksqlDB app values for `KAFKA_TOPIC` (if relevant) -->
